### PR TITLE
Community Organization text and page reference anchors

### DIFF
--- a/guidelines/additional-resources.rst
+++ b/guidelines/additional-resources.rst
@@ -1,3 +1,5 @@
+.. _addtional-resources:
+
 Additional Resources
 =====================
 

--- a/guidelines/community-organization/area-supervisors.rst
+++ b/guidelines/community-organization/area-supervisors.rst
@@ -61,4 +61,4 @@ Consensus Building
 Appointment
 -----------
 
-TODO: Info on appointment/change processes.
+Area Supervisors are appointed by the Sponsor.

--- a/guidelines/community-organization/area-supervisors.rst
+++ b/guidelines/community-organization/area-supervisors.rst
@@ -1,19 +1,64 @@
+.. _area-supervisors:
+
 Area Supervisors
 =====================
 
-Description of role.
+An Area Supervisor is responsible for the day-to-day management of its appointed area.
 
 Area Supervisors
 ----------------
 
-List of supervisors/areas.
+The following list bounds the different areas of responsibility that may be managed by a given Area Supervisor. No Area Supervisors have yet been appointed.
+
+- Foundation Schemas (i.e. Core, Common, Independent, Results, Variables and Directives Schemas)
+- Android Schemas
+- Apple Schemas (iOS, Macintosh)
+- Cisco Schemas (ASA, CatOS, IOS, IOS XE, PixOS)
+- FreeBSD Schemas
+- HP-UX Schemas
+- IBM AIX Schemas
+- Linux Schemas
+- UNIX Schemas
+- Sun Solaris Schemas
+- Juniper JunOS Schemas
+- NETCONF Schemas
+- Microsoft Schemas (i.e. Microsoft Windows, SharePoint)
+- Vmware Schemas (i.e. ESX)
 
 Responsibilities
 ----------------
 
-General info about area supervisor responsibilities.
+Individuals or organizations appointed to be an Area Supervisor are appointed to one or more Areas of Responsibility. In general, each Supervisor MUST:
+
+* Be engaged with the language development process
+* Consult with other Supervisors where appropriate
+* Ensure coverage for their area(s) in the event of an expected absence
+
+Language Governance Responsibilities
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Area Supervisors have can important role to play throughout the language development process, as they are involved in nearly all of its facets.
+
+Language Development
+^^^^^^^^^^^^^^^^^^^^
+
+* Consensus Call: See "Consensus Building" below
+* Release: The Supervisor is responsible for releasing updates to the OVAL Language within its purview, which may require coordination with other Area Supervisors
+
+Update Design Principles
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+* Review Proposed Update: All parties review the proposed update to the design principles
+* Suggest Change: All parties are able to suggest changes to the proposed update
+
+
+Consensus Building
+^^^^^^^^^^^^^^^^^^
+
+* Update Design Principles: See "Update Design Principles" above
+* Create Consensus Call: The Area Supervisor MUST formally call for consensus for the proposal under review in their area
+* Address Issue: When issues are raised during a formal consensus call, the Area Supervisor MUST acknowledge and take appropriate action for the raised issue
 
 Appointment
 -----------
 
-Info on appointment/change processes.
+TODO: Info on appointment/change processes.

--- a/guidelines/community-organization/community-members.rst
+++ b/guidelines/community-organization/community-members.rst
@@ -8,4 +8,4 @@ Community Members are responsible for maintaining OVAL and these governance proc
 Join Us
 -------
 
-TODO: Invitation to join community with suggestions (join the mailing list, raise issues, etc.)
+Joining the OVAL Community is free and all you need to do is join one of our :ref:`oval-mailing-lists` and make a contribution, whiether that be asking questions, answering questions, making language proposals or contributions of other kinds. Invitation to join community with suggestions (join the mailing list, raise issues, etc.)

--- a/guidelines/community-organization/community-members.rst
+++ b/guidelines/community-organization/community-members.rst
@@ -1,9 +1,11 @@
+.. _community-members:
+
 Community Members
 =================
 
-Description of role.
+Community Members are responsible for maintaining OVAL and these governance processes by creating issues, reviewing issues, creating change proposals, collaborating on change proposals, reviewing change proposals and generally contributing to this consensus-driven process.
 
 Join Us
 -------
 
-Invitation to join community with suggestions (join the mailing list, raise issues, etc.)
+TODO: Invitation to join community with suggestions (join the mailing list, raise issues, etc.)

--- a/guidelines/community-organization/index.rst
+++ b/guidelines/community-organization/index.rst
@@ -1,24 +1,31 @@
+.. _community-organization:
+
 Community Organization
 ======================
 
-Welcoming intro TBD.
-
-How the Community Works
------------------------
+Note that requirements langauge used within this section is defined by RFC2119_.
 
 The OVAL Community includes:
 
-* Community Members: brief description and link into Community Member page.
-* The OVAL Leadership Board: brief description and link into The OVAL Leadership Board page.
-* Area Supervisors: brief description and link into Area Supervisors page.
-* OVAL Sponsor: brief description and link into OVAL Sponsor page.
+* :ref:`community-members`: Responsible for maintaining OVAL and these governance processes by creating issues, reviewing issues, creating change proposals, collaborating on change proposals, reviewing change proposals and generally contributing to this consensus-driven process.
+* :ref:`oval-leadership-board`: Steers the OVAL mission and use cases, assists (when needed) with consensus calls, is instrumental in updating design principles, and is responsible for selecting the Official Release(s)..
+* :ref:`area-supervisors`: An Area Supervisor is responsible for the day-to-day management of its appointed area.
+* :ref:`oval-sponsor`: Mainly handles logistics for managing OVAL resources, managing area supervisor appointments, operating the OVAL Repository, and so on.
+
+How the Community Works
+-----------------------
+The gist of OVAL Community operations is basically that any Community Member can make a proposal about anything OVAL-related at any time, and that proposal follows through our proposal process. Community Members, Area Supervisors, the Sponsor, and the Leadership Board may all play a role in the process as a proposal moves from start to finish.
+
 
 .. toctree::
    :caption: Community Organization
    :maxdepth: 2
-   :hidden:   
+   :hidden:
 
    community-members
    oval-leadership-board
    area-supervisors
    oval-sponsor
+
+
+.. _RFC2119: https://www.ietf.org/rfc/rfc2119.txt

--- a/guidelines/community-organization/oval-leadership-board.rst
+++ b/guidelines/community-organization/oval-leadership-board.rst
@@ -45,4 +45,4 @@ As proposals to the language are received in the language development process, w
 Appointment
 -----------
 
-TODO: Info on appointment/change processes.
+Members of the Leadership Board are appointed by the Sponsor. All OVAL Board members participating during the time MITRE was the OVAL Sponsor have been carried forward as members of the Leadership Board.

--- a/guidelines/community-organization/oval-leadership-board.rst
+++ b/guidelines/community-organization/oval-leadership-board.rst
@@ -1,19 +1,48 @@
+.. _oval-leadership-board:
+
 OVAL Leadership Board
 =====================
 
-Description of role.
+In general, members of the leadership board are:
+
+* Responsible for steering the OVAL Mission, Use Cases and providing guidance to other key strategic artifacts including the OVAL Design Principles
+* Expected to monitor project activities and weigh in on issues facing the Community, especially in areas in which they have special expertise
+* Expected to offer guidance to the Community when called on by the Supervisors and/or Community Members, as outlined by the language development process (see "Language Governance Responsibilities" below)
+* Expected to engage in online and in-person events subject to their availability
+* Expected to advocate on behalf of the project to the general public when appropriate
+* Expected to participate in quarterly calls
 
 Leadership Board Members
 ------------------------
 
-List of members.
+TODO: List of members.
 
 Responsibilities
 ----------------
 
-General info about responsibilities.
+Language Governance Responsibilities
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+The Leadership Board plays a role in various aspects of the overall language development process.
+
+Language Development
+^^^^^^^^^^^^^^^^^^^^
+
+In overall language development, the Leadership Board has an important, direct function in providing guiding support to a consensus call, when needed.
+
+* Consensus Call Support: Exact details, TBD.
+
+
+Update Design Principles
+^^^^^^^^^^^^^^^^^^^^^^^^
+As proposals to the language are received in the language development process, we may find a need to update the OVAL Design Principles. A specific subprocess has been defined to handle this case, where the Leadership Board plays an important role.
+
+* Review Proposed Update: All parties review the proposed update to the design principles
+* Suggest Change: All parties are able to suggest changes to the proposed update
+* Create Consensus Call: The leadership board MUST formally call for consensus on the design principle update proposal
+* Address Issue: When issues are raised during a formal consensus call, the Leadership Board MUST acknowledge and take appropriate action for the raised issue
+* Update Design Principles: The Leadership board MUST authorize updates to the design principles (another party, i.e. the sponsor, may actually update the design principles artifact)
 
 Appointment
 -----------
 
-Info on appointment/change processes.
+TODO: Info on appointment/change processes.

--- a/guidelines/community-organization/oval-sponsor.rst
+++ b/guidelines/community-organization/oval-sponsor.rst
@@ -1,19 +1,35 @@
+.. _oval-sponsor:
+
 OVAL Sponsor
 ============
 
-Description of role.
+The Sponsor is essentially the conservator of the OVAL Language, providing infrastructure, logistical, and community support to further the language.
 
 Sponsor
 -------
 
-CIS is sponsor, etc.
+The Center for Internet Security is the presently designated sponsor and can be contacted at oval at cisecurity dot org.
 
 Responsibilities
 ----------------
 
-General info about sponsor responsibilities.
+General Responsibilities
+^^^^^^^^^^^^^^^^^^^^^^^^
+In general, the Sponsor will:
+
+* Function as the OVAL account owner: own all project resources such as GitHub account containing repos, mailing list accounts, etc.
+* Manage Area Supervisor appointments to ensure that each [Area of Responsibility](https://github.com/CISecurity/oval-governance-update/blob/master/process_artifacts/areas-of-responsibility.md) has at least one Area Supervisor.
+
+Language Governance Responsibilities
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+The Sponsor has a less critical role in governing the OVAL Language than other roles. Note that the individual(s)/organization with the Sponsor role may play additional roles in the language development process.
+
+Language Development
+^^^^^^^^^^^^^^^^^^^^
+* Logistical Support: The Sponsor provides logistical support during the release process
+* Release Announcement: The Sponsor is responsible for announcing OVAL Language releases
 
 Appointment
 -----------
 
-Info on appointment/change processes.
+TODO: Info on appointment/change processes.

--- a/guidelines/community-organization/oval-sponsor.rst
+++ b/guidelines/community-organization/oval-sponsor.rst
@@ -32,4 +32,4 @@ Language Development
 Appointment
 -----------
 
-TODO: Info on appointment/change processes.
+TBD: Info on appointment/change processes.

--- a/guidelines/developer-guides/editing-these-guidelines.rst
+++ b/guidelines/developer-guides/editing-these-guidelines.rst
@@ -1,3 +1,5 @@
+.. _editing-these-guidelines:
+
 Editing These Guidelines
 ========================
 

--- a/guidelines/developer-guides/index.rst
+++ b/guidelines/developer-guides/index.rst
@@ -1,13 +1,15 @@
+.. _developer-guides:
+
 Developer Guides
 ================
 
 .. toctree::
    :caption: Developer Guides
    :maxdepth: 3
-   :hidden:   
+   :hidden:
 
    editing-these-guidelines
-   
+
 These guides are intended to help community members learn the mechanics of contributing to the community.
 
 * :doc:`editing-these-guidelines`

--- a/guidelines/getting-started.rst
+++ b/guidelines/getting-started.rst
@@ -1,3 +1,5 @@
+.. _getting-started:
+
 Gettting Started
 ================
 
@@ -53,6 +55,3 @@ Next Steps
 ----------
 
 A list of ways to learn more (read the docs, view additional resources, etc.)
-
-
-

--- a/guidelines/index.rst
+++ b/guidelines/index.rst
@@ -3,6 +3,8 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
+.. _welcome-to-the-guidelines:
+
 Welcome to The OVAL Community Guidelines!
 =========================================
 
@@ -36,7 +38,7 @@ Info about license and link to license page.
 
 .. toctree::
    :caption: The Guidelines
-   :maxdepth: 2   
+   :maxdepth: 2
 
    getting-started
    oval-schema-documentation/index
@@ -51,4 +53,3 @@ Info about license and link to license page.
    mailing-lists
    additional-resources
    terms-of-use
-   

--- a/guidelines/mailing-lists.rst
+++ b/guidelines/mailing-lists.rst
@@ -1,3 +1,5 @@
+.. _oval-mailing-lists:
+
 OVAL Mailing Lists
 ==================
 

--- a/guidelines/oval-content-repos.rst
+++ b/guidelines/oval-content-repos.rst
@@ -1,3 +1,5 @@
+.. _oval-content-repositories:
+
 OVAL Content Repositories
 =========================
 

--- a/guidelines/oval-design-principles.rst
+++ b/guidelines/oval-design-principles.rst
@@ -1,9 +1,11 @@
+.. _oval-design-principles:
+
 OVAL Design Principles
 ======================
 
 Requirements language in this document are defined in `RFC 2119 <https://www.ietf.org/rfc/rfc2119.txt>`_.
-Design principles are categorized as generally applicable or applicable to the versions as indicated. An 
-update mechanism is built into the language development process to account for the fact that new design 
+Design principles are categorized as generally applicable or applicable to the versions as indicated. An
+update mechanism is built into the language development process to account for the fact that new design
 principles may be desired in the future.
 
 General OVAL Design Princples

--- a/guidelines/oval-support-declarations.rst
+++ b/guidelines/oval-support-declarations.rst
@@ -1,3 +1,5 @@
+.. _oval-support-declarations:
+
 OVAL Support Declarations
 =========================
 

--- a/guidelines/proposal-process/alternate-proposals.rst
+++ b/guidelines/proposal-process/alternate-proposals.rst
@@ -1,3 +1,5 @@
+.. _alternate-proposals:
+
 Alternate Proposals
 ===================
 

--- a/guidelines/proposal-process/consensus-building.rst
+++ b/guidelines/proposal-process/consensus-building.rst
@@ -1,3 +1,5 @@
+.. _consensus-building:
+
 Consensus Building
 ==================
 

--- a/guidelines/proposal-process/create-an-issue.rst
+++ b/guidelines/proposal-process/create-an-issue.rst
@@ -1,3 +1,5 @@
+.. _create-an-issue:
+
 Create an Issue
 ===============
 

--- a/guidelines/proposal-process/index.rst
+++ b/guidelines/proposal-process/index.rst
@@ -1,3 +1,5 @@
+.. _proposal-process:
+
 Proposal Process
 ================
 
@@ -18,7 +20,7 @@ High-level overview of proposal process steps with links into more detailed sect
 .. toctree::
    :caption: Proposal Process
    :maxdepth: 2
-   :hidden:   
+   :hidden:
 
    create-an-issue
    initial-proposal

--- a/guidelines/proposal-process/initial-proposal.rst
+++ b/guidelines/proposal-process/initial-proposal.rst
@@ -1,3 +1,5 @@
+.. _initial-proposal:
+
 Initial Proposal
 ================
 

--- a/guidelines/proposal-process/objections.rst
+++ b/guidelines/proposal-process/objections.rst
@@ -1,3 +1,5 @@
+.. _objections:
+
 Objections
 ==========
 

--- a/guidelines/proposal-process/release-process.rst
+++ b/guidelines/proposal-process/release-process.rst
@@ -1,3 +1,5 @@
+.. _release-process:
+
 Release Process
 ===============
 

--- a/guidelines/specifications.rst
+++ b/guidelines/specifications.rst
@@ -1,3 +1,5 @@
+.. _specifications:
+
 OVAL Specifications
 ===================
 

--- a/guidelines/versioning.rst
+++ b/guidelines/versioning.rst
@@ -1,3 +1,5 @@
+.. _versioning:
+
 Versioning
 ==========
 

--- a/terms-of-use.rst
+++ b/terms-of-use.rst
@@ -1,3 +1,5 @@
+.. _terms-of-use:
+
 Terms of Use
 ============
 


### PR DESCRIPTION
Reference anchors are now added to the top of our .rst pages and are
set to the convention of using the page header as the anchor text
(lower case and hyphenated). For example, an .rst file with  a page
header of "Reference Me" would have a reference string as follows:
":ref:`reference-me`.