### PR TITLE
File Attribute Type

### DIFF
--- a/oval-schemas/windows-definitions-schema.xsd
+++ b/oval-schemas/windows-definitions-schema.xsd
@@ -9480,6 +9480,11 @@
                                 <xsd:documentation>This value is reserved for system use.</xsd:documentation>
                             </xsd:annotation>
                         </xsd:enumeration>
+                        <xsd:enumeration value="">
+                              <xsd:annotation>
+                                    <xsd:documentation>The empty string value is permitted here to allow for empty elements associated with variable references.</xsd:documentation>
+                              </xsd:annotation>
+                        </xsd:enumeration>
                   </xsd:restriction>
             </xsd:simpleContent>
       </xsd:complexType>

--- a/oval-schemas/windows-system-characteristics-schema.xsd
+++ b/oval-schemas/windows-system-characteristics-schema.xsd
@@ -4100,6 +4100,11 @@
                             <xsd:documentation>This value is reserved for system use.</xsd:documentation>
                         </xsd:annotation>
                     </xsd:enumeration>
+                    <xsd:enumeration value="">
+                         <xsd:annotation>
+                              <xsd:documentation>The empty string value is permitted here to allow for detailed error reporting.</xsd:documentation>
+                         </xsd:annotation>
+                    </xsd:enumeration>
                </xsd:restriction>
           </xsd:simpleContent>
      </xsd:complexType>


### PR DESCRIPTION
Added allowable empty string enumeration value for Entity(State|Item)FileAttributeType, per standard for other OVAL enumeration types.