### PR TITLE
Improve OVAL Leadership Board-related process documentation (fixes #97)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.DS_Store
+*.vscode
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/guidelines/community-organization/oval-leadership-board.rst
+++ b/guidelines/community-organization/oval-leadership-board.rst
@@ -3,92 +3,94 @@
 OVAL Leadership Board
 =====================
 
-In general, members of the leadership board are:
+In general, members of the OVAL Leadership Board are:
 
 * Responsible for steering the OVAL Mission, Use Cases and providing guidance to other key strategic artifacts including the OVAL Design Principles
 * Expected to monitor project activities and weigh in on issues facing the Community, especially in areas in which they have special expertise
 * Expected to offer guidance to the Community when called on by the Supervisors and/or Community Members, as outlined by the language development process (see "Language Governance Responsibilities" below)
 * Expected to engage in online and in-person events subject to their availability
 * Expected to advocate on behalf of the project to the general public when appropriate
-* Expected to participate in quarterly calls
+* Expected to participate in quarterly calls and vote when votes are called
 
 Leadership Board Members
 ------------------------
 
-* Current Members
+Current Members
+^^^^^^^^^^^^^^^
 
-  * Organizational
+* Organizational
 
-    * `Assuria Limited <https://www.assuria-online.com/>`_ - Chris Wood
-    * `BeyondTrust, Inc. <https://www.beyondtrust.com/>`_ - Morey Haber
-    * `Center for Internet Security <https://www.cisecurity.org>`_ - William Munyan, Adam Montville
-    * `Cisco Systems, Inc. <https://www.cisco.com/>`_ - Panos Kampanakis, Omar Santos
-    * `Depository Trust & Clearing Corporation (DTCC) <https://www.dtcc.com/>`_ - Dale Rich
-    * `HPE <https://www.hp.com/country/us/en/uc/welcome.html>`_ - TBD
-    * `IBM <https://www.ibm.com/>`_ - Luigi Pichetti
-    * `Joval Continuous Monitoring <https://joval.org/>`_ - David Solin, David Ries
-    * `McAfee <https://www.mcafee.com/>`_ - Kent Landfield
-    * `Modulo <https://www.modulo.com/>`_ - Alberto Bastos
-    * `National Institute of Standards and Technology <https://www.nist.gov/>`_ - Melanie Cook, Dave Waltermire
-    * `Qualys, Inc. <https://www.qualys.com/>`_ - Tigran Gevorgyan
-    * `Red Hat, Inc. <https://www.redhat.com/>`_ - Šimon Lukašík, Matej Tyc
-    * `Rockport Systems <https://www.rockportsystems.com/>`_ - Carl Banzhof
-    * `SecPod Technologies <https://www.secpod.com/>`_ - Chandrashekhar B
-    * `SPAWAR, U.S. Navy <https://www.spawar.navy.mil/>`_ - Jack Vander Pol
-    * `Symantec Corporation <https://www.symantec.com/>`_ - Jamie Cromer, Amaresh Shirsat
-    * `ThreatGuard, Inc. <https://www.threatguard.com/>`_ - Randy Taylor
-    * `Unified Compliance <https://www.unifiedcompliance.com/>`_ - Stephen Pillero
-    * `VMware <https://www.vmware.com/>`_ - Dennis Moreau
+  * `Assuria Limited <https://www.assuria-online.com/>`_ - Chris Wood
+  * `BeyondTrust, Inc. <https://www.beyondtrust.com/>`_ - Morey Haber
+  * `Center for Internet Security <https://www.cisecurity.org>`_ - William Munyan, Adam Montville
+  * `Cisco Systems, Inc. <https://www.cisco.com/>`_ - Panos Kampanakis, Omar Santos
+  * `Depository Trust & Clearing Corporation (DTCC) <https://www.dtcc.com/>`_ - Dale Rich
+  * `HPE <https://www.hp.com/country/us/en/uc/welcome.html>`_ - TBD
+  * `IBM <https://www.ibm.com/>`_ - Luigi Pichetti
+  * `Joval Continuous Monitoring <https://joval.org/>`_ - David Solin, David Ries
+  * `McAfee <https://www.mcafee.com/>`_ - Kent Landfield
+  * `Modulo <https://www.modulo.com/>`_ - Alberto Bastos
+  * `National Institute of Standards and Technology <https://www.nist.gov/>`_ - Melanie Cook, Dave Waltermire
+  * `Qualys, Inc. <https://www.qualys.com/>`_ - Tigran Gevorgyan
+  * `Red Hat, Inc. <https://www.redhat.com/>`_ - Šimon Lukašík, Matej Tyc
+  * `Rockport Systems <https://www.rockportsystems.com/>`_ - Carl Banzhof
+  * `SecPod Technologies <https://www.secpod.com/>`_ - Chandrashekhar B
+  * `SPAWAR, U.S. Navy <https://www.spawar.navy.mil/>`_ - Jack Vander Pol
+  * `Symantec Corporation <https://www.symantec.com/>`_ - Jamie Cromer, Amaresh Shirsat
+  * `ThreatGuard, Inc. <https://www.threatguard.com/>`_ - Randy Taylor
+  * `Unified Compliance <https://www.unifiedcompliance.com/>`_ - Stephen Pillero
+  * `VMware <https://www.vmware.com/>`_ - Dennis Moreau
 
-  * Individual
+* Individual
 
-    * Blake Frantz
-    * Nils Puhlmann
+  * Blake Frantz
+  * Nils Puhlmann
 
-* Past Members
+Past Members
+^^^^^^^^^^^^
 
-  * Emeritus
+* Emeritus
 
-    * Jay Beale
-    * Anton Chuvakin
-    * Mark Cox
-    * Javier Fernandez-Sanguino
-    * Robert Hollis
-    * Matt Hansbury
-    * Tim "TK" Keanini
+  * Jay Beale
+  * Anton Chuvakin
+  * Mark Cox
+  * Javier Fernandez-Sanguino
+  * Robert Hollis
+  * Matt Hansbury
+  * Tim "TK" Keanini
 
-  * Former
+* Former
 
-    * Melissa Albanese
-    * Anthony Busciglio
-    * Nick Connor
-    * Pat Fetty
-    * Jay Graver
-    * Gary Miliefsky
-    * Stephen Quinn
-    * Noah Salzman
-    * Amol Sarwate
-    * Michael Tan
-    * Eric Walker
-    * Kurt Seifried
-    * Martin Preisler
-    * Rosario Gangemi
+  * Melissa Albanese
+  * Anthony Busciglio
+  * Nick Connor
+  * Pat Fetty
+  * Jay Graver
+  * Gary Miliefsky
+  * Stephen Quinn
+  * Noah Salzman
+  * Amol Sarwate
+  * Michael Tan
+  * Eric Walker
+  * Kurt Seifried
+  * Martin Preisler
+  * Rosario Gangemi
 
 Responsibilities
 ----------------
 
 Language Governance Responsibilities
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-The Leadership Board plays a role in various aspects of the overall language development process.
+The OVAL Leadership Board plays a role in key aspects of the overall language development process.
 
 Language Development
 """"""""""""""""""""
-In overall language development, the Leadership Board has an important, direct function in providing guiding support to a consensus call, when needed. Such support may be needed when consensus is too difficult for an Area Supervisor to judge. The IETF has published an excellent informational RFC on the subject: `RFC 7282 <https://datatracker.ietf.org/doc/rfc7282/>`_.
+In overall language development, the OVAL Leadership Board has an important, direct function in providing guiding support to a consensus call, when needed. Such support may be needed when consensus is too difficult for an Area Supervisor to judge. The IETF has published an excellent informational RFC on the subject: `RFC 7282 <https://datatracker.ietf.org/doc/rfc7282/>`_.
 
 
 Update Design Principles
 """"""""""""""""""""""""
-As proposals to the language are received in the language development process, we may find a need to update the OVAL Design Principles. A specific subprocess has been defined to handle this case, where the Leadership Board plays an important role.
+As proposals to the language are received in the language development process, we may find a need to update the OVAL Design Principles. A specific subprocess has been defined to handle this case, where the OVAL Leadership Board plays an important role.
 
 * **Review Proposed Update:** All parties review the proposed update to the design principles
 * **Suggest Change:** All parties are able to suggest changes to the proposed update
@@ -96,9 +98,95 @@ As proposals to the language are received in the language development process, w
 * **Address Issue:** When issues are raised during a formal consensus call, the Leadership Board MUST acknowledge and take appropriate action for the raised issue
 * **Update Design Principles:** The Leadership board MUST authorize updates to the design principles (another party, i.e. the sponsor, may actually update the design principles artifact)
 
-Appointment
------------
-New members of the Leadership Board are nominated by one or more existing members of the Leadership Board. Appointment to the board is confirmed by a simple majority vote by the Leadership Board as a whole. [#]_ The Sponsor will facilitate such votes in a timely basis.
+Official OVAL Release
+"""""""""""""""""""""
+The OVAL Leadership Board is responsible for selecting a Stable releass at least once per year to be the Official release.
+
+Processes
+---------
+
+Membership
+^^^^^^^^^^
+
+New Members
+"""""""""""
+New members of the OVAL Leadership Board are nominated by one or more existing members. Appointment to the board is confirmed by a vote. [#]_ The Sponsor will facilitate such votes in a timely basis.
+
+Recognition of Former Members
+"""""""""""""""""""""""""""""
+Former OVAL Leadership Board members will be considered for recognition by the Sponsor under the following guidelines:
+
+* Emeritus Member: a person who made significant contributions to this community
+* Former Contributing Member: a person who made clear contributions to this community
+
+If a person did not make a measurable contribution to this community, then the person is not identified as a former member.
+
+Changing Roles in an Organization
+"""""""""""""""""""""""""""""""""
+If a current OVAL Leadership Board member switches roles within an organization and serving on the Board no longer makes sense, they must notify the Sponsor. Upon notification, the member will be given an opportunity to nominate a new member to represent the organization. This prospective member will be considered in accordance with the New Members process.
+
+Leaving an Organization
+"""""""""""""""""""""""
+If a current OVAL Leadership Board member is going to leave an organization, they must notify the Sponsor. Upon notification, the current member will be given two options:
+
+* They can continue to serve on the Board under their new organization.
+* They can relinquish their membership and will be considered for recognition as a former member as described under Recognition of Former Members.
+
+In either case, the organization that is losing representation on the OVAL Leadership Board will be given an opportunity to nominate a new member that will be considered in accordance with the New Members Process.
+
+Revocation of Membership
+""""""""""""""""""""""""""""""
+If the Sponsor has evidence that an OVAL Leadership Board member is not fulfilling their responsibilities, they may be removed. The following process defines the steps that the Sponsor must follow in order to revoke the membership of a current member.
+
+* The Sponsor must provide the member with a warning of revocation at least two (2) months before revocation is scheduled to occur explaining the reasons for revocation.
+* The Sponsor may delay the date of revocation.
+* Prior to revocation, the member will be given an opportunity to get in good standing according to the agreed upon responsibilities. If membership no longer makes sense, it will be terminated.
+* If the member fails to get in good standing, their membership will be revoked and they will not be recognized as a former member.
+
+Voting
+^^^^^^
+
+What Is Voted On?
+"""""""""""""""""
+The OVAL Leadership Board will be required to vote on the following matters.
+
+* Approval of an official OVAL release
+* Approval of new OVAL Leadership Board members
+
+Lastly, a vote may be requested for any other issue deemed necessary by the OVAL Leadership Board or the Sponsor. 
+Each request will be considered on a case-by-case by the Sponsor to see if it is within the Board's responsibilities as described herein. If a request falls within one of these areas, the request will be processed and a vote will be announced. To request a vote, a member can either publicly send a message to the Board mailing list or privately send a message to the Sponsor.
+
+Who May Vote?
+"""""""""""""
+All active members of the OVAL Leadership Board are eligible to cast a vote. However, only one vote per organization will be accepted. Emeritus members are not eligible to cast a vote, but, they can provide their input on matters before a decision is made.
+
+Announcing a Vote
+"""""""""""""""""
+All matters, which require a vote, will be announced on the Board mailing list and the OVAL developer mailing list along with the timeline. The timeline will provide a deadline for community and Board discussion as well as dates for when the voting period begins and ends.
+
+Casting a Vote
+"""""""""""""""
+All voting ballots will be distributed through email over the Board mailing list and will typically require that an organization select one or more options as well as provide justification. Please note that all votes and justifications will be posted to the OVAL Community repository to provide the community with transparency into the voting process and for record-keeping purposes.
+
+Handling Multiple Votes from an Organization
+""""""""""""""""""""""""""""""""""""""""""""
+In the event that multiple, conflicting votes are cast by the same organization, only the first vote received will count. If all members of the affected organization reaching consensus on changing a vote, they may request their vote be changed by emailing the Board mailing list before voting has closed. The Sponsor will consider the reasons for changing the vote and determine which of the votes should be considered valid. Please note that any changes to a vote will be considered on a case-by-case basis and should only be approved given extenuating circumstances.
+
+Total Possible Votes
+""""""""""""""""""""
+Because only one vote may be accepted per organization, the total number of possible votes equals the number of distinct organizations having organizational members plus the number of individual members.
+
+Quorum
+""""""
+In order to reach a quorum, votes must be cast by a simple majority of the Total Possible Votes. If a quorum is not reached, a vote will be deemed invalid.
+
+Reaching a Decision
+"""""""""""""""""""
+A decision is reached if there is a quorum and the results of the vote indicate that a simple majority of the votes are for or against a particular issue. If there is a tie, the Sponsor will re-open the discussion and schedule another vote on the issue.
+
+Publishing Vote Results
+"""""""""""""""""""""""
+Once the OVAL Leadership Board reaches a decision, the results of the vote will be announced over the Board mailing list and the OVAL developer mailing list, and posted to the OVAL Community repository.
 
 .. rubric: Footnotes
 


### PR DESCRIPTION
Migrates the relevant/missing MITRE documentation over to our current site for clarity and completeness, without changing any of the missing rules/processes themselves.

See https://github.com/OVAL-Community/OVAL/issues/97
