### PR TITLE
Introduce a schema directory README that points out to oval-community-guidelines.readthedocs.io

### DIFF
--- a/oval-schemas/README.md
+++ b/oval-schemas/README.md
@@ -1,0 +1,2 @@
+This directory contains authoritative OVAL schemas in form of XSD files.
+If you are after a human-readable description of those schemas, check out [OVAL Schemas on readthedocs.io](https://oval-community-guidelines.readthedocs.io/en/latest/oval-schema-documentation/index.html) that are available in the HTML form.


### PR DESCRIPTION
Having more than one "official" place that contains schemas looks like asking for trouble - when schemas are updated, there is a risk that one of those repositories will fall behind and mislead others.

I have also come across https://github.com/OVALProject/Language/tree/master/docs that contains human-readable OVAL schema  documentation in form of Markdown files that is extracted from XSDs. What is the relation of the OVALProject to CIS/community OVAL repositories?