### PR TITLE
Proposal : ADDING auditdline_test

### DIFF
--- a/oval-schemas/linux-definitions-schema.xsd
+++ b/oval-schemas/linux-definitions-schema.xsd
@@ -2781,10 +2781,32 @@
                <xsd:choice>
                  <xsd:element ref="oval-def:set"/>
                  <xsd:sequence>
-                   <xsd:element name="filter_key" type="oval-def:EntityObjectStringType" nillable="true">
+					<xsd:element name="filepath" type="oval-def:EntityObjectStringType" nillable="true">
                      <xsd:annotation>
-                       <xsd:documentation>As described in the auditctl(8) manpage, the filter key is an arbitrary string of text that can be up to 31 bytes long. It can uniquely identify the audit records produced by a rule. You may have more than one key on a rule.</xsd:documentation>
-                       <xsd:documentation>If the xsi:nil attribute is set to true, all auditd rules must be present in the system characteristics (auditdline_item).</xsd:documentation>
+                       <xsd:documentation>The filepath element specifies the path and name of a file to evaluate.</xsd:documentation>
+					   <xsd:documentation>If the xsi:nil attribute is set to true, then the rules specified are the ones executed at runtime.</xsd:documentation>
+					   <xsd:appinfo>
+					   <sch:pattern id="linux-def_auditfilepath">
+							<sch:rule context="linux-def:auditdline_object/linux-def:filepath">
+								<sch:assert test="not(@operation) or @operation='equals'"><sch:value-of select="../@id"/> - operation attribute for the filepath entity of an auditdline_object should be 'equals', note that this overrules the general operation attribute validation (i.e. follow this one)</sch:assert>
+							</sch:rule>
+						</sch:pattern>
+					   </xsd:appinfo>
+                     </xsd:annotation>
+                   </xsd:element>
+                   <xsd:element name="field" type="oval-def:EntityObjectStringType" minOccurs="0" maxOccurs="1">
+                     <xsd:annotation>
+                       <xsd:documentation>As described in the auditctl(8) manpage, the field is an association of name, operation and value used to parameter the audit rule</xsd:documentation>
+                     </xsd:annotation>
+                   </xsd:element>
+				   <xsd:element name="syscall" type="oval-def:EntityObjectStringType" minOccurs="0" maxOccurs="1">
+                     <xsd:annotation>
+                       <xsd:documentation>As described in the auditctl(8) manpage, the syscall can be any syscall name or number. The word 'all' may also be used.</xsd:documentation>
+                     </xsd:annotation>
+                   </xsd:element>
+				   <xsd:element name="permission" type="oval-def:EntityObjectAuditPermissionType" minOccurs="0" maxOccurs="1">
+                     <xsd:annotation>
+                       <xsd:documentation>As described in the auditctl(8) manpage, the permission describes the action that triggers the audit record.</xsd:documentation>
                      </xsd:annotation>
                    </xsd:element>
                    <xsd:element ref="oval-def:filter" minOccurs="0" maxOccurs="unbounded"/>
@@ -2803,11 +2825,27 @@
          <xsd:complexContent>
            <xsd:extension base="oval-def:StateType">
              <xsd:sequence>
-               <xsd:element name="filter_key" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
-                 <xsd:annotation>
-                   <xsd:documentation>As described in the auditctl(8) manpage, the filter key is an arbitrary string of text that can be up to 31 bytes long. It can uniquely identify the audit records produced by a rule. You may have more than one key on a rule.</xsd:documentation>
-                 </xsd:annotation>
-               </xsd:element>
+				<xsd:element name="filepath" type="oval-def:EntityStateStringType"  minOccurs="0" maxOccurs="1">
+				 <xsd:annotation>
+				   <xsd:documentation>The filepath element specifies the path and name of a file to evaluate.</xsd:documentation>
+				   <xsd:documentation>If the xsi:nil attribute is set to true, then the rules specified are the ones executed at runtime.</xsd:documentation>
+				 </xsd:annotation>
+				</xsd:element>
+				<xsd:element name="field" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+				 <xsd:annotation>
+				   <xsd:documentation>As described in the auditctl(8) manpage, the field is an association of name, operation and value used to parameter the audit rule</xsd:documentation>
+				 </xsd:annotation>
+				</xsd:element>
+				<xsd:element name="syscall" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+				 <xsd:annotation>
+				   <xsd:documentation>As described in the auditctl(8) manpage, the syscall can be any syscall name or number. The word 'all' may also be used.</xsd:documentation>
+				 </xsd:annotation>
+				</xsd:element>
+				<xsd:element name="permission" type="oval-def:EntityStateAuditPermissionType" minOccurs="0" maxOccurs="1">
+				 <xsd:annotation>
+				   <xsd:documentation>As described in the auditctl(8) manpage, the permission describes the action that triggers the audit record.</xsd:documentation>
+				 </xsd:annotation>
+				</xsd:element>
                <xsd:element name="audit_line" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
                  <xsd:annotation>
                    <xsd:documentation>A rule written on a single line like returned by the auditctl -k command.</xsd:documentation>
@@ -2815,7 +2853,9 @@
                </xsd:element>
                <xsd:element name="line_number" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
                  <xsd:annotation>
-                   <xsd:documentation>The line number of the rule, which can be considered as the rule number regarding that there is one rule per line. This number starts at 1 which means that the number of the first rule returned is 1.</xsd:documentation>
+                   <xsd:documentation>The instance entity calls out a specific match of the pattern. It can have any integer value. If the value is a non-negative integer, the index of the specific match of the pattern is counted from the beginning of the set of matches of that pattern. The first match is given an instance value of 1, the second match is given an instance value of 2, and so on. For non-negative values, the 'less than' and 'less than or equal' operations imply the object is operating only on non-negative values. Frequently, this entity will be defined as 'greater than or equal' to 1 or 'greater than' 0, either of which results in the object representing the set of all matches of the pattern.</xsd:documentation>
+				   <xsd:documentation>Negative values are used to simplify collection of pattern match occurrences counting backwards from the final match. To find the final match, use an instance of -1; the penultimate match is found using an instance value of -2, and so on. For negative values, the 'greater than' and 'greater than or equal' operations imply the object is operating only on negative values. For example, searching for instances greater than or equal to -2 would yield only the last two maches.</xsd:documentation>
+				   <xsd:documentation>Note that the main purpose of the instance item entity is to provide uniqueness for different auditdline_items that results from multiple matches of a given pattern against the same rule collection, and they will always have positive values.</xsd:documentation>                                   
                  </xsd:annotation>
                </xsd:element>
              </xsd:sequence>
@@ -3254,6 +3294,74 @@
                     <xsd:enumeration value="mls">
                          <xsd:annotation>
                               <xsd:documentation>'mls' indicates Multi Level Security protection. MLS is pretty complex and pretty much not used in most situations. </xsd:documentation>
+                         </xsd:annotation>
+                    </xsd:enumeration>
+                    <xsd:enumeration value="">
+                         <xsd:annotation>
+                              <xsd:documentation>The empty string value is permitted here to allow for empty elements associated with variable references.</xsd:documentation>
+                         </xsd:annotation>
+                    </xsd:enumeration>
+               </xsd:restriction>
+          </xsd:simpleContent>
+     </xsd:complexType>
+	 <xsd:complexType name="EntityObjectAuditPermissionType">
+          <xsd:annotation>
+               <xsd:documentation>The EntityObjectAuditPermissionType complex type restricts a string value to the set of auditd permissions values. The empty string is also allowed to support the empty element associated with variable references. Note that when using pattern matches and variables care must be taken to ensure that the regular expression and variable values align with the enumerated values</xsd:documentation>
+          </xsd:annotation>
+          <xsd:simpleContent>
+               <xsd:restriction base="oval-def:EntityStateStringType">
+                    <xsd:enumeration value="read">
+                         <xsd:annotation>
+                              <xsd:documentation>'read' indicates the 'auditctl -p r' value.</xsd:documentation>
+                         </xsd:annotation>
+                    </xsd:enumeration>
+                    <xsd:enumeration value="write">
+                         <xsd:annotation>
+                              <xsd:documentation>'write' indicates the 'auditctl -p w' value.</xsd:documentation>
+                         </xsd:annotation>
+                    </xsd:enumeration>
+                    <xsd:enumeration value="execute">
+                         <xsd:annotation>
+                              <xsd:documentation>'execute' indicates the 'auditctl -p e' value. </xsd:documentation>
+                         </xsd:annotation>
+                    </xsd:enumeration>
+					<xsd:enumeration value="attribute_change">
+                         <xsd:annotation>
+                              <xsd:documentation>'attribute_change' indicates the 'auditctl -p a' value. </xsd:documentation>
+                         </xsd:annotation>
+                    </xsd:enumeration>
+                    <xsd:enumeration value="">
+                         <xsd:annotation>
+                              <xsd:documentation>The empty string value is permitted here to allow for empty elements associated with variable references.</xsd:documentation>
+                         </xsd:annotation>
+                    </xsd:enumeration>
+               </xsd:restriction>
+          </xsd:simpleContent>
+     </xsd:complexType>
+	 <xsd:complexType name="EntityStateAuditPermissionType">
+          <xsd:annotation>
+               <xsd:documentation>The EntityStateAuditPermissionType complex type restricts a string value to the set of auditd permissions values. The empty string is also allowed to support the empty element associated with variable references. Note that when using pattern matches and variables care must be taken to ensure that the regular expression and variable values align with the enumerated values</xsd:documentation>
+          </xsd:annotation>
+          <xsd:simpleContent>
+               <xsd:restriction base="oval-def:EntityStateStringType">
+                    <xsd:enumeration value="read">
+                         <xsd:annotation>
+                              <xsd:documentation>'read' indicates the 'auditctl -p r' value.</xsd:documentation>
+                         </xsd:annotation>
+                    </xsd:enumeration>
+                    <xsd:enumeration value="write">
+                         <xsd:annotation>
+                              <xsd:documentation>'write' indicates the 'auditctl -p w' value.</xsd:documentation>
+                         </xsd:annotation>
+                    </xsd:enumeration>
+                    <xsd:enumeration value="execute">
+                         <xsd:annotation>
+                              <xsd:documentation>'execute' indicates the 'auditctl -p e' value. </xsd:documentation>
+                         </xsd:annotation>
+                    </xsd:enumeration>
+					<xsd:enumeration value="attribute_change">
+                         <xsd:annotation>
+                              <xsd:documentation>'attribute_change' indicates the 'auditctl -p a' value. </xsd:documentation>
                          </xsd:annotation>
                     </xsd:enumeration>
                     <xsd:enumeration value="">

--- a/oval-schemas/linux-definitions-schema.xsd
+++ b/oval-schemas/linux-definitions-schema.xsd
@@ -2759,7 +2759,6 @@
      <xsd:element name="auditdline_object" substitutionGroup="oval-def:object">
        <xsd:annotation>
          <xsd:documentation>The auditdline_object element is used by a auditdline_test to define the object to be evaluated. Each object extends the standard ObjectType as defined in the oval-definitions-schema and one should refer to the ObjectType description for more information. The common set element allows complex objects to be created using filters and set logic. Again, please refer to the description of the set element in the oval-definitions-schema.</xsd:documentation>
-         <xsd:documentation>A auditdline_object consists of an filter_key entity that is the same as the -k parameter of the auditctl -l command.</xsd:documentation>
          <xsd:appinfo>
            <sch:pattern id="linux_auditdline_object_verify_filter_state">
              <sch:rule context="linux:auditdline_object//oval-def:filter">

--- a/oval-schemas/linux-definitions-schema.xsd
+++ b/oval-schemas/linux-definitions-schema.xsd
@@ -2719,6 +2719,110 @@
                </xsd:complexContent>
           </xsd:complexType>
      </xsd:element>
+	 <!-- =============================================================================== -->
+     <!-- ==============================  AUDITD LINE TEST  ============================= -->
+     <!-- =============================================================================== -->
+     <!-- Originaly authored by French Ministry of Army (DGA-MI) -->
+     <xsd:element name="auditdline_test" substitutionGroup="oval-def:test">
+       <xsd:annotation>
+         <xsd:documentation>The auditdline_test is used to check the living rules of the auditd service. It extends the standard TestType as defined in the oval-definitions-schema and one should refer to the TestType description for more information. The required object element references a auditdline_object and the optional state element specifies the data to check.</xsd:documentation>
+         <xsd:appinfo>
+           <oval:element_mapping>
+             <oval:test>auditdline_test</oval:test>
+             <oval:object>auditdline_object</oval:object>
+             <oval:state>auditdline_state</oval:state>
+             <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#linux">auditdline_item</oval:item>
+           </oval:element_mapping>
+         </xsd:appinfo>
+         <xsd:appinfo>
+           <sch:pattern id="linux_auditdlinetst">
+             <sch:rule context="linux:auditdline_test/linux:object">
+               <sch:assert test="@object_ref=ancestor::oval-def:oval_definitions/oval-def:objects/linux:auditdline_object/@id"><sch:value-of select="../@id"/> - the object child element of a auditdline_test must reference a auditdline_object</sch:assert>
+             </sch:rule>
+             <sch:rule context="linux:auditdline_test/linux:state">
+               <sch:assert test="@state_ref=ancestor::oval-def:oval_definitions/oval-def:states/linux:auditdline_state/@id"><sch:value-of select="../@id"/> - the state child element of a auditdline_test must reference a auditdline_state</sch:assert>
+             </sch:rule>
+           </sch:pattern>
+         </xsd:appinfo>
+       </xsd:annotation>
+       <xsd:complexType>
+         <xsd:complexContent>
+           <xsd:extension base="oval-def:TestType">
+             <xsd:sequence>
+               <xsd:element name="object" type="oval-def:ObjectRefType" />
+               <xsd:element name="state" type="oval-def:StateRefType" minOccurs="0" maxOccurs="unbounded"/>
+             </xsd:sequence>
+           </xsd:extension>
+         </xsd:complexContent>
+       </xsd:complexType>
+     </xsd:element>
+     <xsd:element name="auditdline_object" substitutionGroup="oval-def:object">
+       <xsd:annotation>
+         <xsd:documentation>The auditdline_object element is used by a auditdline_test to define the object to be evaluated. Each object extends the standard ObjectType as defined in the oval-definitions-schema and one should refer to the ObjectType description for more information. The common set element allows complex objects to be created using filters and set logic. Again, please refer to the description of the set element in the oval-definitions-schema.</xsd:documentation>
+         <xsd:documentation>A auditdline_object consists of an filter_key entity that is the same as the -k parameter of the auditctl -l command.</xsd:documentation>
+         <xsd:appinfo>
+           <sch:pattern id="linux_auditdline_object_verify_filter_state">
+             <sch:rule context="linux:auditdline_object//oval-def:filter">
+               <sch:let name="parent_object" value="ancestor::linux:auditdline_object"/>
+               <sch:let name="parent_object_id" value="$parent_object/@id"/>
+               <sch:let name="state_ref" value="."/>
+               <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
+               <sch:let name="state_name" value="local-name($reffed_state)"/>
+               <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
+               <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#linux') and ($state_name='auditdline_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+             </sch:rule>
+           </sch:pattern>
+         </xsd:appinfo>
+       </xsd:annotation>
+       <xsd:complexType>
+         <xsd:complexContent>
+           <xsd:extension base="oval-def:ObjectType">
+             <xsd:sequence>
+               <xsd:choice>
+                 <xsd:element ref="oval-def:set"/>
+                 <xsd:sequence>
+                   <xsd:element name="filter_key" type="oval-def:EntityObjectStringType" nillable="true">
+                     <xsd:annotation>
+                       <xsd:documentation>As described in the auditctl(8) manpage, the filter key is an arbitrary string of text that can be up to 31 bytes long. It can uniquely identify the audit records produced by a rule. You may have more than one key on a rule.</xsd:documentation>
+                       <xsd:documentation>If the xsi:nil attribute is set to true, all auditd rules must be present in the system characteristics (auditdline_item).</xsd:documentation>
+                     </xsd:annotation>
+                   </xsd:element>
+                   <xsd:element ref="oval-def:filter" minOccurs="0" maxOccurs="unbounded"/>
+                 </xsd:sequence>
+               </xsd:choice>
+             </xsd:sequence>
+           </xsd:extension>
+         </xsd:complexContent>
+       </xsd:complexType>
+     </xsd:element>
+     <xsd:element name="auditdline_state" substitutionGroup="oval-def:state">
+       <xsd:annotation>
+         <xsd:documentation>The auditdline_state element defines the different information that can be used to evaluate the auditd rules. This includes the filter key, the corresponding rule and the line number of the rule. Please refer to the individual elements in the schema for more details about what each represents.</xsd:documentation>
+       </xsd:annotation>
+       <xsd:complexType>
+         <xsd:complexContent>
+           <xsd:extension base="oval-def:StateType">
+             <xsd:sequence>
+               <xsd:element name="filter_key" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                 <xsd:annotation>
+                   <xsd:documentation>As described in the auditctl(8) manpage, the filter key is an arbitrary string of text that can be up to 31 bytes long. It can uniquely identify the audit records produced by a rule. You may have more than one key on a rule.</xsd:documentation>
+                 </xsd:annotation>
+               </xsd:element>
+               <xsd:element name="audit_line" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                 <xsd:annotation>
+                   <xsd:documentation>A rule written on a single line like returned by the auditctl -k command.</xsd:documentation>
+                 </xsd:annotation>
+               </xsd:element>
+               <xsd:element name="line_number" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+                 <xsd:annotation>
+                   <xsd:documentation>The line number of the rule, which can be considered as the rule number regarding that there is one rule per line. This number starts at 1 which means that the number of the first rule returned is 1.</xsd:documentation>
+                 </xsd:annotation>
+               </xsd:element>
+             </xsd:sequence>
+           </xsd:extension>
+         </xsd:complexContent>
+       </xsd:complexType>
+     </xsd:element>
      <!-- =============================================================================== -->
      <!-- =============================================================================== -->
      <!-- =============================================================================== -->

--- a/oval-schemas/linux-system-characteristics-schema.xsd
+++ b/oval-schemas/linux-system-characteristics-schema.xsd
@@ -1198,11 +1198,27 @@
                <xsd:complexContent>
                     <xsd:extension base="oval-sc:ItemType">
                          <xsd:sequence>
-                              <xsd:element name="filter_key" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
-                                   <xsd:annotation>
-                                        <xsd:documentation>>As described in the auditctl(8) manpage, the filter key is an arbitrary string of text that can be up to 31 bytes long. It can uniquely identify the audit records produced by a rule. You may have more than one key on a rule.</xsd:documentation>
-                                   </xsd:annotation>
-                              </xsd:element>
+                              <xsd:element name="filepath" type="oval-sc:EntityItemStringType"  minOccurs="0" maxOccurs="1">
+								 <xsd:annotation>
+								   <xsd:documentation>The filepath element specifies the path and name of a file to evaluate.</xsd:documentation>
+								   <xsd:documentation>If the xsi:nil attribute is set to true, then the rules specified are the ones executed at runtime.</xsd:documentation>
+								 </xsd:annotation>
+								</xsd:element>
+								<xsd:element name="field" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+								 <xsd:annotation>
+								   <xsd:documentation>As described in the auditctl(8) manpage, the field is an association of name, operation and value used to parameter the audit rule</xsd:documentation>
+								 </xsd:annotation>
+								</xsd:element>
+								<xsd:element name="syscall" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+								 <xsd:annotation>
+								   <xsd:documentation>As described in the auditctl(8) manpage, the syscall can be any syscall name or number. The word 'all' may also be used.</xsd:documentation>
+								 </xsd:annotation>
+								</xsd:element>
+								<xsd:element name="permission" type="oval-sc:EntityItemAuditPermissionType" minOccurs="0" maxOccurs="1">
+								 <xsd:annotation>
+								   <xsd:documentation>As described in the auditctl(8) manpage, the permission describes the action that triggers the audit record.</xsd:documentation>
+								 </xsd:annotation>
+								</xsd:element>
                               <xsd:element name="auditline" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
                                    <xsd:annotation>
                                         <xsd:documentation>A rule written on a single line like returned by the auditctl -k command.</xsd:documentation>
@@ -1210,8 +1226,10 @@
                               </xsd:element>
                               <xsd:element name="line_number" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
                                    <xsd:annotation>
-                                        <xsd:documentation>The line number of the rule, which can be considered as the rule number regarding that there is one rule per line. This number starts at 1 which means that the number of the first rule returned is 1.</xsd:documentation>
-                                   </xsd:annotation>
+                                        <xsd:documentation>The instance entity calls out a specific match of the pattern. It can have any integer value. If the value is a non-negative integer, the index of the specific match of the pattern is counted from the beginning of the set of matches of that pattern. The first match is given an instance value of 1, the second match is given an instance value of 2, and so on. For non-negative values, the 'less than' and 'less than or equal' operations imply the object is operating only on non-negative values. Frequently, this entity will be defined as 'greater than or equal' to 1 or 'greater than' 0, either of which results in the object representing the set of all matches of the pattern.</xsd:documentation>
+									    <xsd:documentation>Negative values are used to simplify collection of pattern match occurrences counting backwards from the final match. To find the final match, use an instance of -1; the penultimate match is found using an instance value of -2, and so on. For negative values, the 'greater than' and 'greater than or equal' operations imply the object is operating only on negative values. For example, searching for instances greater than or equal to -2 would yield only the last two maches.</xsd:documentation>
+									    <xsd:documentation>Note that the main purpose of the instance item entity is to provide uniqueness for different auditdline_items that results from multiple matches of a given pattern against the same rule collection, and they will always have positive values.</xsd:documentation>                                   
+								   </xsd:annotation>
                               </xsd:element>
                          </xsd:sequence>
                     </xsd:extension>
@@ -1591,6 +1609,40 @@
                     <xsd:enumeration value="mls">
                          <xsd:annotation>
                               <xsd:documentation>'mls' indicates Multi Level Security protection. MLS is pretty complex and pretty much not used in most situations. </xsd:documentation>
+                         </xsd:annotation>
+                    </xsd:enumeration>
+                    <xsd:enumeration value="">
+                         <xsd:annotation>
+                              <xsd:documentation>The empty string value is permitted here to allow for empty elements associated with variable references.</xsd:documentation>
+                         </xsd:annotation>
+                    </xsd:enumeration>
+               </xsd:restriction>
+          </xsd:simpleContent>
+     </xsd:complexType>
+	 <xsd:complexType name="EntityItemAuditPermissionType">
+          <xsd:annotation>
+               <xsd:documentation>The EntityItemAuditPermissionType complex type restricts a string value to the set of auditd permissions values. The empty string is also allowed to support the empty element associated with variable references. Note that when using pattern matches and variables care must be taken to ensure that the regular expression and variable values align with the enumerated values</xsd:documentation>
+          </xsd:annotation>
+          <xsd:simpleContent>
+               <xsd:restriction base="oval-def:EntityStateStringType">
+                    <xsd:enumeration value="read">
+                         <xsd:annotation>
+                              <xsd:documentation>'read' indicates the 'auditctl -p r' value.</xsd:documentation>
+                         </xsd:annotation>
+                    </xsd:enumeration>
+                    <xsd:enumeration value="write">
+                         <xsd:annotation>
+                              <xsd:documentation>'write' indicates the 'auditctl -p w' value.</xsd:documentation>
+                         </xsd:annotation>
+                    </xsd:enumeration>
+                    <xsd:enumeration value="execute">
+                         <xsd:annotation>
+                              <xsd:documentation>'execute' indicates the 'auditctl -p e' value. </xsd:documentation>
+                         </xsd:annotation>
+                    </xsd:enumeration>
+					<xsd:enumeration value="attribute_change">
+                         <xsd:annotation>
+                              <xsd:documentation>'attribute_change' indicates the 'auditctl -p a' value. </xsd:documentation>
                          </xsd:annotation>
                     </xsd:enumeration>
                     <xsd:enumeration value="">

--- a/oval-schemas/linux-system-characteristics-schema.xsd
+++ b/oval-schemas/linux-system-characteristics-schema.xsd
@@ -1186,6 +1186,38 @@
                </xsd:complexContent>
           </xsd:complexType>
      </xsd:element>
+	 <!-- =============================================================================== -->
+     <!-- ==============================  AUDITD LINE ITEM  ============================= -->
+     <!-- =============================================================================== -->
+     <!-- Originaly authored by French Ministry of Army (DGA-MI) -->
+     <xsd:element name="auditdline_item" substitutionGroup="oval-sc:item">
+          <xsd:annotation>
+               <xsd:documentation>This item stores results from checking the living rules of the auditd service.</xsd:documentation>
+          </xsd:annotation>
+          <xsd:complexType>
+               <xsd:complexContent>
+                    <xsd:extension base="oval-sc:ItemType">
+                         <xsd:sequence>
+                              <xsd:element name="filter_key" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>>As described in the auditctl(8) manpage, the filter key is an arbitrary string of text that can be up to 31 bytes long. It can uniquely identify the audit records produced by a rule. You may have more than one key on a rule.</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>
+                              <xsd:element name="auditline" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>A rule written on a single line like returned by the auditctl -k command.</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>
+                              <xsd:element name="line_number" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>The line number of the rule, which can be considered as the rule number regarding that there is one rule per line. This number starts at 1 which means that the number of the first rule returned is 1.</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>
+                         </xsd:sequence>
+                    </xsd:extension>
+               </xsd:complexContent>
+          </xsd:complexType>
+     </xsd:element>
      <!-- =============================================================================== -->
      <!-- =============================================================================== -->
      <!-- =============================================================================== -->


### PR DESCRIPTION
This publication is made by Sopra Steria France.
The following tests were initially authored by French Ministry of Army (DGA-MI).

The auditdline_test is used to check the living rules of the auditd service.
The networkfirewall_test is used to check the living filtering rules of the network firewall on a UNIX system.

Related issue : #114