### PR TITLE
Adding GH Action to attached schema files to GH release asset list

### DIFF
--- a/.github/workflows/buildRelease.yml
+++ b/.github/workflows/buildRelease.yml
@@ -1,0 +1,29 @@
+name: Build Release
+
+on:
+  release:
+    types: [ published, edited ]
+
+jobs:
+  buildRelease:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Build Release
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          echo "Perform and build steps here such as docs, .sch, .xsl, zip files, etc..."
+      - name: Attach Release Artifacts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+          TAG: ${{ github.ref_name }}
+        run: |
+            SCHEMA_FILES=$(ls oval-schemas/*.xsd)
+            gh release upload $TAG $SCHEMA_FILES --clobber --repo $OWNER/$REPO


### PR DESCRIPTION
Adding a GH workflow for which is triggered by publishing/editing a release (ie, via [the creation of a new release](https://github.com/OVAL-Community/OVAL/releases/new)) will attach the schema files to the release asset list as per the example in the below screenshot.  In the future this can be updated to build and attach other artifacts to the asset list, as it contains a placeholder for where that would be done.

![image](https://github.com/user-attachments/assets/cf3d201c-d701-4b26-a0e4-b7750ca49841)
