### PR TITLE
Remove dirs from gh action clean script

### DIFF
--- a/.github/workflows/clean_for_release.yaml
+++ b/.github/workflows/clean_for_release.yaml
@@ -10,9 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CLEAN_FILES: |
-        Area Supervisors
-        Email List Archives
-        OVAL-Board
         guidelines
         tools
         .gitignore


### PR DESCRIPTION
OVAL-Board, Area Supervisors, and Email List Archives dirs were removed from the repository, so they are not needed into the clean up script anymore.