### PR TITLE
Add new independent test to support running shell commands called shellcommand

### DIFF
--- a/oval-schemas/independent-definitions-schema.xsd
+++ b/oval-schemas/independent-definitions-schema.xsd
@@ -1039,7 +1039,7 @@ The evaluation of the object should always produce at least one item.  If the ob
                                     <xsd:choice>
                                           <xsd:element ref="oval-def:set"/>
                                           <xsd:sequence>
-                                                <xsd:element name="shell" type="oval-def:EntityObjectShellType" use="optional" default="'cmd' on Windows, 'sh' on UNIX/linux, 'Zsh' on MacOS" >
+                                                <xsd:element name="shell" type="oval-def:EntityObjectShellType" use="required" >
                                                       <xsd:annotation>
                                                             <xsd:documentation>The shell entity defines the specific shell to use (e.g. bash, csh, ksh, etc.). Any tool collecting information for this object will need to know the shell in order to use it properly.</xsd:documentation>
                                                       </xsd:annotation>
@@ -2682,9 +2682,9 @@ SERVERPROPERTY('IsClustered') AS [is_clustered]
                                     <xsd:documentation>The korn shell (ksh).</xsd:documentation>
                               </xsd:annotation>
                         </xsd:enumeration>
-                        <xsd:enumeration value="Zsh">
+                        <xsd:enumeration value="zsh">
                               <xsd:annotation>
-                                    <xsd:documentation>The Z shell (Zsh).</xsd:documentation>
+                                    <xsd:documentation>The Z shell (zsh).</xsd:documentation>
                               </xsd:annotation>
                         </xsd:enumeration>
                         <xsd:enumeration value="cmd">
@@ -2731,9 +2731,9 @@ SERVERPROPERTY('IsClustered') AS [is_clustered]
                                     <xsd:documentation>The korn shell (ksh).</xsd:documentation>
                               </xsd:annotation>
                         </xsd:enumeration>
-                        <xsd:enumeration value="Zsh">
+                        <xsd:enumeration value="zsh">
                               <xsd:annotation>
-                                    <xsd:documentation>The Z shell (Zsh).</xsd:documentation>
+                                    <xsd:documentation>The Z shell (zsh).</xsd:documentation>
                               </xsd:annotation>
                         </xsd:enumeration>
                         <xsd:enumeration value="cmd">

--- a/oval-schemas/independent-definitions-schema.xsd
+++ b/oval-schemas/independent-definitions-schema.xsd
@@ -969,6 +969,153 @@
             </xsd:complexType>
       </xsd:element>
       <!-- =============================================================================== -->
+      <!-- ============================  SHELLCOMMAND TEST  =============================== -->
+      <!-- =============================================================================== -->
+      <xsd:element name="shellcommand_test" substitutionGroup="oval-def:test">
+            <xsd:annotation>
+                  <xsd:documentation>The shellcommand_test is used to check the values produced by the running of the command (or embedded script, not an external script file) found in the object 'command' element. It extends the standard TestType as defined in the oval-definitions-schema and one should refer to the TestType description for more information. The required object element references a shellcommand_object and the optional state element references a shellcommand_state that specifies the information to check.
+                                   
+Since this test requires the running of code supplied by content and since SCAP applications commonly run with elevated privileges, significant responsibilty falls to the content author to do no harm.  This also requires that any content stream that employs this test MUST be from a known trusted source and be digitally signed.  The use of any executables that are not supplied by the installed operating system is highly discouraged.</xsd:documentation>
+                  <xsd:appinfo>
+                        <oval:element_mapping>
+                              <oval:test>shellcommand_test</oval:test>
+                              <oval:object>shellcommand_object</oval:object>
+                              <oval:state>shellcommand_state</oval:state>
+                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#independent">shellcommand_item</oval:item>
+                        </oval:element_mapping>
+                  </xsd:appinfo>
+                  <xsd:appinfo>
+                        <sch:pattern id="ind-def_shellcommand_tst">
+                              <sch:rule context="ind-def:shellcommand_test/ind-def:object">
+                                    <sch:assert test="@object_ref=ancestor::oval-def:oval_definitions/oval-def:objects/ind-def:shellcommand_object/@id"><sch:value-of select="../@id"/> - the object child element of a shellcommand_test must reference a shellcommand_object</sch:assert>
+                              </sch:rule>
+                              <sch:rule context="ind-def:shellcommand_test/ind-def:state">
+                                    <sch:assert test="@state_ref=ancestor::oval-def:oval_definitions/oval-def:states/ind-def:shellcommand_state/@id"><sch:value-of select="../@id"/> - the state child element of a shellcommand_test must reference a shellcommand_state</sch:assert>
+                              </sch:rule>
+                        </sch:pattern>
+                  </xsd:appinfo>
+            </xsd:annotation>
+            <xsd:complexType>
+                  <xsd:complexContent>
+                        <xsd:extension base="oval-def:TestType">
+                              <xsd:sequence>
+                                    <xsd:element name="object" type="oval-def:ObjectRefType" />
+                                    <xsd:element name="state" type="oval-def:StateRefType" minOccurs="0" maxOccurs="unbounded"/>
+                              </xsd:sequence>
+                        </xsd:extension>
+                  </xsd:complexContent>
+            </xsd:complexType>
+      </xsd:element>
+      
+      <xsd:element name="shellcommand_object" substitutionGroup="oval-def:object">
+            <xsd:annotation>
+                  <xsd:documentation>The shellcommand_object is used by a shellcommand_test to define a command (or shell script) to be run and a pattern to filter result lines. Each object extends the standard ObjectType as defined in the oval-definitions-schema and one should refer to the ObjectType description for more information. The common set element allows complex objects to be created using filters and set logic.</xsd:documentation>
+                  <xsd:appinfo>
+                        <sch:pattern id="ind-def_shellcommand_object_verify_filter_state">
+                              <sch:rule context="ind-def:shellcommand_object//oval-def:filter">
+                                    <sch:let name="parent_object" value="ancestor::ind-def:shellcommand_object"/>
+                                    <sch:let name="parent_object_id" value="$parent_object/@id"/>
+                                    <sch:let name="state_ref" value="."/>
+                                    <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
+                                    <sch:let name="state_name" value="local-name($reffed_state)"/>
+                                    <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
+                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#independent') and ($state_name='shellcommand_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                              </sch:rule>
+                        </sch:pattern>
+                  </xsd:appinfo>
+            </xsd:annotation>
+            <xsd:complexType>
+                  <xsd:complexContent>
+                        <xsd:extension base="oval-def:ObjectType">
+                              <xsd:sequence>
+                                    <xsd:choice>
+                                          <xsd:element ref="oval-def:set"/>
+                                          <xsd:sequence>
+                                                <xsd:element name="shell" type="ind-def:EntityObjectShellType">
+                                                      <xsd:annotation>
+                                                            <xsd:documentation>The shell entity defines the specific shell interpeter use. Any tool looking to collect information about this object will need to know the shell in order to use it properly.</xsd:documentation>
+                                                      </xsd:annotation>
+                                                </xsd:element>
+                                                <xsd:element name="command" type="oval-def:EntityObjectStringType"  minOccurs="1" maxOccurs="1">
+                                                      <xsd:annotation>
+                                                            <xsd:documentation>The command element specifies the command string to be run on the target system.  Since this command or script will be executed on the target system and since SCAP applications commonly run with elevated privileges, significant responsibilty falls to the content author to do no harm.  This also requires that any content stream that employs this test MUST be from a known trusted source and be digitally signed.  The use of executables that are not supplied by the installed operating system is highly discouraged.</xsd:documentation>
+                                                      </xsd:annotation>
+                                                </xsd:element>
+                                                <xsd:element name="pattern" type="oval-def:EntityObjectStringType"  minOccurs="0" maxOccurs="1">
+                                                      <xsd:annotation>
+                                                            <xsd:documentation>The 'pattern' is a regular expression that identifies lines in 'command' results that are to produce OVAL items.   Any result line that matches the pattern is kept as an OVAL item.  Any that do not are discarded.  If the pattern element is empty or does not exist, all results lines are kept.  Importantly, this test does not support the capture of subexpressions as the textfilecontent test do.  The shell command or script should produce concise results obfuscating the need for subexpression.</xsd:documentation>
+                                                            <xsd:documentation>Note that when using regular expressions, OVAL supports a common subset of the regular expression character classes, operations, expressions and other lexical tokens defined within Perl 5's regular expression specification. For more information on the supported regular expression syntax in OVAL see: http://oval.mitre.org/language/about/re_support_5.6.html.</xsd:documentation>
+                                                            <xsd:appinfo>
+                                                                  <sch:pattern id="ind-def_txt54objpattern">
+                                                                        <sch:rule context="ind-def:textfilecontent54_object/ind-def:pattern">
+                                                                              <sch:assert test="@operation='pattern match'"><sch:value-of select="../@id" /> - operation attribute for the pattern entity of a textfilecontent54_object should be 'pattern match'</sch:assert>
+                                                                        </sch:rule>
+                                                                  </sch:pattern>
+                                                            </xsd:appinfo>
+                                                      </xsd:annotation>
+                                                </xsd:element>
+                                                                                                
+                                                <xsd:element ref="oval-def:filter" minOccurs="0" maxOccurs="unbounded"/>
+                                          </xsd:sequence>
+                                    </xsd:choice>
+                              </xsd:sequence>
+                        </xsd:extension>
+                  </xsd:complexContent>
+            </xsd:complexType>
+      </xsd:element>
+      <xsd:element name="shellcommand_state" substitutionGroup="oval-def:state">
+            <xsd:annotation>
+                  <xsd:documentation>The shellcommand_state contains the entity that are used to check the value(s) returned by the shellcommand_object.  Note that only the 'result' element is meaningful in OVAL item to state comparisons.  All other state entities (label, command, and pattern) are echoed, verbatim, from the same elements in the associated shellcommand_object.</xsd:documentation>
+            </xsd:annotation>
+            <xsd:complexType>
+                  <xsd:complexContent>
+                        <xsd:extension base="oval-def:StateType">
+                              <xsd:sequence>
+                                    <xsd:element name="shell" type="oval-def:EntityStateShellType" minOccurs="0" maxOccurs="1">
+                                          <xsd:annotation>
+                                                <xsd:documentation>The shell element contains the shell used to perform the command.</xsd:documentation>
+                                          </xsd:annotation>
+                                    </xsd:element>
+                                    
+                                    <xsd:element name="command" type="oval-def:EntityStateAnySimpleType" minOccurs="1" maxOccurs="1">
+                                          <xsd:annotation>
+                                                <xsd:documentation>The 'command' element specifies the command string to be run on the target system and must match, verbatim, the same element in the associated shellcommand_object.</xsd:documentation>
+                                          </xsd:annotation>
+                                    </xsd:element>                                    
+                                    <xsd:element name="pattern" type="oval-def:EntityStateStringType"  minOccurs="0" maxOccurs="1">
+                                          <xsd:annotation>
+                                                <xsd:documentation>The 'pattern' is a regular expression that identifies lines in 'command' results that are to produce OVAL items and must match, verbatim, the same element in the associated shellcommand_object.</xsd:documentation>
+                                                <xsd:appinfo>
+                                                      <sch:pattern id="ind-def_txt54objpattern">
+                                                            <sch:rule context="ind-def:textfilecontent54_state/ind-def:pattern">
+                                                                  <sch:assert test="@operation='pattern match'"><sch:value-of select="../@id" /> - operation attribute for the pattern entity of a textfilecontent54_object should be 'pattern match'</sch:assert>
+                                                            </sch:rule>
+                                                      </sch:pattern>
+                                                </xsd:appinfo>
+                                          </xsd:annotation>
+                                    </xsd:element>
+			                        <xsd:element name="exit_status" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+										<xsd:annotation>
+											<xsd:documentation>The exit status value from the command</xsd:documentation>
+										</xsd:annotation>
+									</xsd:element>
+                                    <xsd:element name="stdout_line" type="oval-def:EntityStateAnySimpleType" minOccurs="1" maxOccurs="1">
+                                          <xsd:annotation>
+                                                <xsd:documentation>The result element contains the standard output of a successful run of the command string.  Each result line should produce an OVAL item.  The object pattern can be used to filter (exclude) unwanted lines.</xsd:documentation>
+                                          </xsd:annotation>
+                                    </xsd:element>
+                                    <xsd:element name="stderr_line" type="oval-def:EntityStateAnySimpleType" minOccurs="1" maxOccurs="1">
+                                          <xsd:annotation>
+                                                <xsd:documentation>The result element contains the standard error of a run of the command string.  Each result line should produce an OVAL item.  The object pattern can be used to filter (exclude) unwanted lines.</xsd:documentation>
+                                          </xsd:annotation>
+                                    </xsd:element>
+
+                              </xsd:sequence>
+                        </xsd:extension>
+                  </xsd:complexContent>
+            </xsd:complexType>
+      </xsd:element>
+      <!-- =============================================================================== -->
       <!-- =================================  SQL TEST  ================================== -->
       <!-- =============================================================================== -->
       <xsd:element name="sql_test" substitutionGroup="oval-def:test">
@@ -2491,6 +2638,94 @@ SERVERPROPERTY('IsClustered') AS [is_clustered]
                   </xsd:simpleType>
             </xsd:attribute>
       </xsd:complexType>
+      <xsd:complexType name="EntityObjectShellType">
+            <xsd:annotation>
+                  <xsd:documentation>The EntityObjectShellType complex type defines a string entity value that is restricted to a set of command shells. The empty string is also allowed to support empty elements associated with variable references.</xsd:documentation>
+            </xsd:annotation>
+            <xsd:simpleContent>
+                  <xsd:restriction base="oval-def:EntityObjectStringType">
+                        <xsd:enumeration value="sh">
+                              <xsd:annotation>
+                                    <xsd:documentation>The borne shell (sh)</xsd:documentation>
+                              </xsd:annotation>
+                        </xsd:enumeration>
+                        <xsd:enumeration value="bash">
+                              <xsd:annotation>
+                                    <xsd:documentation>The gnu borne again shell (bash).</xsd:documentation>
+                              </xsd:annotation>
+                        </xsd:enumeration>
+                        <xsd:enumeration value="csh">
+                              <xsd:annotation>
+                                    <xsd:documentation>The C shell (csh).</xsd:documentation>
+                              </xsd:annotation>
+                        </xsd:enumeration>
+                        <xsd:enumeration value="ksh">
+                              <xsd:annotation>
+                                    <xsd:documentation>The korn shell (ksh).</xsd:documentation>
+                              </xsd:annotation>
+                        </xsd:enumeration>
+                        <xsd:enumeration value="cmd">
+                              <xsd:annotation>
+                                    <xsd:documentation>The Microsoft Windows command prompt (cmd).</xsd:documentation>
+                              </xsd:annotation>
+                        </xsd:enumeration>
+                        <xsd:enumeration value="powershell">
+                              <xsd:annotation>
+                                    <xsd:documentation>The Microsoft Powershell prompt (powershell).</xsd:documentation>
+                              </xsd:annotation>
+                        </xsd:enumeration>
+                        <xsd:enumeration value="">
+                              <xsd:annotation>
+                                    <xsd:documentation>The empty string value is permitted here to allow for empty elements associated with variable references.</xsd:documentation>
+                              </xsd:annotation>
+                        </xsd:enumeration>
+                  </xsd:restriction>
+            </xsd:simpleContent>
+      </xsd:complexType>	  
+      <xsd:complexType name="EntityStateShellType">
+            <xsd:annotation>
+                  <xsd:documentation>The EntityStateShellType complex type defines a string entity value that is restricted to a set of command shells. The empty string is also allowed to support empty elements associated with variable references.</xsd:documentation>
+            </xsd:annotation>
+            <xsd:simpleContent>
+                  <xsd:restriction base="oval-def:EntityStateStringType">
+                        <xsd:enumeration value="sh">
+                              <xsd:annotation>
+                                    <xsd:documentation>The borne shell (sh)</xsd:documentation>
+                              </xsd:annotation>
+                        </xsd:enumeration>
+                        <xsd:enumeration value="bash">
+                              <xsd:annotation>
+                                    <xsd:documentation>The gnu borne again shell (bash).</xsd:documentation>
+                              </xsd:annotation>
+                        </xsd:enumeration>
+                        <xsd:enumeration value="csh">
+                              <xsd:annotation>
+                                    <xsd:documentation>The C shell (csh).</xsd:documentation>
+                              </xsd:annotation>
+                        </xsd:enumeration>
+                        <xsd:enumeration value="ksh">
+                              <xsd:annotation>
+                                    <xsd:documentation>The korn shell (ksh).</xsd:documentation>
+                              </xsd:annotation>
+                        </xsd:enumeration>
+                        <xsd:enumeration value="cmd">
+                              <xsd:annotation>
+                                    <xsd:documentation>The Microsoft Windows command prompt (cmd).</xsd:documentation>
+                              </xsd:annotation>
+                        </xsd:enumeration>
+                        <xsd:enumeration value="powershell">
+                              <xsd:annotation>
+                                    <xsd:documentation>The Microsoft Powershell prompt (powershell).</xsd:documentation>
+                              </xsd:annotation>
+                        </xsd:enumeration>
+                        <xsd:enumeration value="">
+                              <xsd:annotation>
+                                    <xsd:documentation>The empty string value is permitted here to allow for empty elements associated with variable references.</xsd:documentation>
+                              </xsd:annotation>
+                        </xsd:enumeration>
+                  </xsd:restriction>
+            </xsd:simpleContent>
+      </xsd:complexType>	
       <xsd:complexType name="EntityObjectEngineType">
             <xsd:annotation>
                   <xsd:documentation>The EntityObjectEngineType complex type defines a string entity value that is restricted to a set of enumerations. Each valid enumeration is a valid database engine. The empty string is also allowed to support empty elements associated with variable references.</xsd:documentation>

--- a/oval-schemas/independent-definitions-schema.xsd
+++ b/oval-schemas/independent-definitions-schema.xsd
@@ -968,6 +968,7 @@
                   </xsd:complexContent>
             </xsd:complexType>
       </xsd:element>
+	  
       <!-- =============================================================================== -->
       <!-- ============================  SHELLCOMMAND TEST  =============================== -->
       <!-- =============================================================================== -->
@@ -975,7 +976,7 @@
             <xsd:annotation>
                   <xsd:documentation>The shellcommand_test is used to check the values produced by the running of the command (or embedded script, not an external script file) found in the object 'command' element. It extends the standard TestType as defined in the oval-definitions-schema and one should refer to the TestType description for more information. The required object element references a shellcommand_object and the optional state element references a shellcommand_state that specifies the information to check.
                                    
-Since this test requires the running of code supplied by content and since SCAP applications commonly run with elevated privileges, significant responsibilty falls to the content author to do no harm.  This also requires that any content stream that employs this test MUST be from a known trusted source and be digitally signed.  The use of any executables that are not supplied by the installed operating system is highly discouraged.</xsd:documentation>
+				Since this test requires the running of code supplied by content and since SCAP applications commonly run with elevated privileges, significant responsibilty falls to the content author to do no harm.  This also requires that any content stream that employs this test MUST be from a known trusted source and be digitally signed.  The use of any executables that are not supplied by the installed operating system is highly discouraged.</xsd:documentation>
                   <xsd:appinfo>
                         <oval:element_mapping>
                               <oval:test>shellcommand_test</oval:test>
@@ -1033,7 +1034,7 @@ Since this test requires the running of code supplied by content and since SCAP 
                                           <xsd:sequence>
                                                 <xsd:element name="shell" type="ind-def:EntityObjectShellType">
                                                       <xsd:annotation>
-                                                            <xsd:documentation>The shell entity defines the specific shell interpeter use. Any tool looking to collect information about this object will need to know the shell in order to use it properly.</xsd:documentation>
+                                                            <xsd:documentation>The shell entity defines the specific shell interpreter to use. Any tool looking to collect information about this object will need to know the shell in order to use it properly.</xsd:documentation>
                                                       </xsd:annotation>
                                                 </xsd:element>
                                                 <xsd:element name="command" type="oval-def:EntityObjectStringType"  minOccurs="1" maxOccurs="1">
@@ -1043,12 +1044,15 @@ Since this test requires the running of code supplied by content and since SCAP 
                                                 </xsd:element>
                                                 <xsd:element name="pattern" type="oval-def:EntityObjectStringType"  minOccurs="0" maxOccurs="1">
                                                       <xsd:annotation>
-                                                            <xsd:documentation>The 'pattern' is a regular expression that identifies lines in 'command' results that are to produce OVAL items.   Any result line that matches the pattern is kept as an OVAL item.  Any that do not are discarded.  If the pattern element is empty or does not exist, all results lines are kept.  Importantly, this test does not support the capture of subexpressions as the textfilecontent test do.  The shell command or script should produce concise results obfuscating the need for subexpression.</xsd:documentation>
+                                                            <xsd:documentation>The 'pattern' is a regular expression that identifies lines in 'command' results that are to produce OVAL items.   Any result line that matches the pattern is kept as an OVAL item.  Any that do not are discarded.  If the pattern element is empty or does not exist, all results lines are kept.  
+															
+															A subexpression (using parentheses) can call out a piece of the matched stdout_line to test. For example, the pattern abc(.*)xyz would look for a block of text in the file that starts with abc and ends with xyz, with the subexpression being all the characters that exist in between. The value of the subexpression can then be tested using the subexpression entity of a shellcommand_state. Note that if the pattern, starting at the same point in the line, matches more than one block of text, then it matches the longest. For example, given a file with abcdefxyzxyzabc, then the pattern abc(.*)xyz would match the block abcdefxyzxyz. Subexpressions also match the longest possible substrings, subject to the constraint that the whole match be as long as possible, with subexpressions starting earlier in the pattern taking priority over ones starting later.
+															</xsd:documentation>
                                                             <xsd:documentation>Note that when using regular expressions, OVAL supports a common subset of the regular expression character classes, operations, expressions and other lexical tokens defined within Perl 5's regular expression specification. For more information on the supported regular expression syntax in OVAL see: http://oval.mitre.org/language/about/re_support_5.6.html.</xsd:documentation>
                                                             <xsd:appinfo>
                                                                   <sch:pattern id="ind-def_txt54objpattern">
                                                                         <sch:rule context="ind-def:textfilecontent54_object/ind-def:pattern">
-                                                                              <sch:assert test="@operation='pattern match'"><sch:value-of select="../@id" /> - operation attribute for the pattern entity of a textfilecontent54_object should be 'pattern match'</sch:assert>
+                                                                              <sch:assert test="@operation='pattern match'"><sch:value-of select="../@id" /> - operation attribute for the pattern entity of a shellcommand_object should be 'pattern match'</sch:assert>
                                                                         </sch:rule>
                                                                   </sch:pattern>
                                                             </xsd:appinfo>
@@ -1065,7 +1069,7 @@ Since this test requires the running of code supplied by content and since SCAP 
       </xsd:element>
       <xsd:element name="shellcommand_state" substitutionGroup="oval-def:state">
             <xsd:annotation>
-                  <xsd:documentation>The shellcommand_state contains the entity that are used to check the value(s) returned by the shellcommand_object.  Note that only the 'result' element is meaningful in OVAL item to state comparisons.  All other state entities (label, command, and pattern) are echoed, verbatim, from the same elements in the associated shellcommand_object.</xsd:documentation>
+                  <xsd:documentation>The shellcommand_state contains the entities that are used to check the values returned by the shellcommand_object.  Note that the state entities shell, command, and pattern are echoed, verbatim, from the same elements in the associated shellcommand_object.</xsd:documentation>
             </xsd:annotation>
             <xsd:complexType>
                   <xsd:complexContent>
@@ -1088,7 +1092,7 @@ Since this test requires the running of code supplied by content and since SCAP 
                                                 <xsd:appinfo>
                                                       <sch:pattern id="ind-def_txt54objpattern">
                                                             <sch:rule context="ind-def:textfilecontent54_state/ind-def:pattern">
-                                                                  <sch:assert test="@operation='pattern match'"><sch:value-of select="../@id" /> - operation attribute for the pattern entity of a textfilecontent54_object should be 'pattern match'</sch:assert>
+                                                                  <sch:assert test="@operation='pattern match'"><sch:value-of select="../@id" /> - operation attribute for the pattern entity of a shellcommand_object should be 'pattern match'</sch:assert>
                                                             </sch:rule>
                                                       </sch:pattern>
                                                 </xsd:appinfo>
@@ -1096,17 +1100,19 @@ Since this test requires the running of code supplied by content and since SCAP 
                                     </xsd:element>
 			                        <xsd:element name="exit_status" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
 										<xsd:annotation>
-											<xsd:documentation>The exit status value from the command</xsd:documentation>
+											<xsd:documentation>The exit_status entity represents the exist status returned by the system for the execution of the object command.</xsd:documentation>
 										</xsd:annotation>
 									</xsd:element>
-                                    <xsd:element name="stdout_line" type="oval-def:EntityStateAnySimpleType" minOccurs="1" maxOccurs="1">
+                                    <xsd:element name="stdout_line" type="oval-def:EntityStateAnySimpleType" minOccurs="0" maxOccurs="1">
                                           <xsd:annotation>
-                                                <xsd:documentation>The result element contains the standard output of a successful run of the command string.  Each result line should produce an OVAL item.  The object pattern can be used to filter (exclude) unwanted lines.</xsd:documentation>
+                                                <xsd:documentation>The stdout_line entity represents a line from the STDOUT output of a successful run of the command string that matched the specified object pattern.</xsd:documentation>
                                           </xsd:annotation>
                                     </xsd:element>
-                                    <xsd:element name="stderr_line" type="oval-def:EntityStateAnySimpleType" minOccurs="1" maxOccurs="1">
+                                    <xsd:element name="stderr_line" type="oval-def:EntityStateAnySimpleType" minOccurs="0" maxOccurs="1">
                                           <xsd:annotation>
-                                                <xsd:documentation>The result element contains the standard error of a run of the command string.  Each result line should produce an OVAL item.  The object pattern can be used to filter (exclude) unwanted lines.</xsd:documentation>
+                                                <xsd:documentation>The stderr_line element represents a line from the STDERR output of a run of the command string that matched the specified object pattern.  Each line of STDERR produced by the command execution will produce a single shellcommand item.</xsd:documentation>
+					<!-- WHICH ONE????? -->		
+												 <xsd:documentation>The stderr(_line) element contains any output to STDERR from a run of the object command.</xsd:documentation>
                                           </xsd:annotation>
                                     </xsd:element>
 
@@ -1115,6 +1121,8 @@ Since this test requires the running of code supplied by content and since SCAP 
                   </xsd:complexContent>
             </xsd:complexType>
       </xsd:element>
+	  
+	  
       <!-- =============================================================================== -->
       <!-- =================================  SQL TEST  ================================== -->
       <!-- =============================================================================== -->

--- a/oval-schemas/independent-definitions-schema.xsd
+++ b/oval-schemas/independent-definitions-schema.xsd
@@ -1039,7 +1039,7 @@ The evaluation of the object should always produce at least one item.  If the ob
                                     <xsd:choice>
                                           <xsd:element ref="oval-def:set"/>
                                           <xsd:sequence>
-                                                <xsd:element name="shell" type="oval-def:EntityObjectStringType">
+                                                <xsd:element name="shell" type="oval-def:EntityObjectShellType" use="optional" default="'cmd' on Windows, 'sh' on UNIX/linux, 'Zsh' on MacOS" >
                                                       <xsd:annotation>
                                                             <xsd:documentation>The shell entity defines the specific shell to use (e.g. bash, csh, ksh, etc.). Any tool collecting information for this object will need to know the shell in order to use it properly.</xsd:documentation>
                                                       </xsd:annotation>
@@ -1053,7 +1053,7 @@ The evaluation of the object should always produce at least one item.  If the ob
                                                       <xsd:annotation>
                                                             <xsd:documentation>The 'pattern' is a regular expression that identifies lines in 'command' results that are to produce OVAL items.   Any result line via STDOUT that matches the pattern is kept as an item stdout_line element.  Any that do not are discarded.  If the pattern element is empty or does not exist, all results lines are kept.  
 															
-A subexpression (using parentheses) can call out a piece of the matched stdout_line to test. For example, the pattern abc(.*)xyz would look for a block of text in the file that starts with abc and ends with xyz, with the subexpression being all the characters that exist in between. The value of the subexpression can then be tested using the subexpression entity of a shellcommand_state. Note that if the pattern, starting at the same point in the line, matches more than one block of text, then it matches the longest. For example, given a file with abcdefxyzxyzabc, then the pattern abc(.*)xyz would match the block abcdefxyzxyz. Subexpressions also match the longest possible substrings, subject to the constraint that the whole match be as long as possible, with subexpressions starting earlier in the pattern taking priority over ones starting later.
+A subexpression (using parentheses) can call out a piece of the matched stdout_line to test. For example, the pattern abc(.*)xyz would look for a block of text in the output that starts with abc and ends with xyz, with the subexpression being all the characters that exist in between. The value of the subexpression can then be tested using the subexpression entity of a shellcommand_state. Note that if the pattern, starting at the same point in the line, matches more than one block of text, then it matches the longest. For example, given output with abcdefxyzxyzabc, then the pattern abc(.*)xyz would match the block abcdefxyzxyz. Subexpressions also match the longest possible substrings, subject to the constraint that the whole match be as long as possible, with subexpressions starting earlier in the pattern taking priority over ones starting later.
 
 															</xsd:documentation>
                                                             <xsd:documentation>Note that when using regular expressions, OVAL supports a common subset of the regular expression character classes, operations, expressions and other lexical tokens defined within Perl 5's regular expression specification. For more information on the supported regular expression syntax in OVAL see: http://oval.mitre.org/language/about/re_support_5.6.html.</xsd:documentation>
@@ -1083,7 +1083,7 @@ A subexpression (using parentheses) can call out a piece of the matched stdout_l
                   <xsd:complexContent>
                         <xsd:extension base="oval-def:StateType">
                               <xsd:sequence>
-                                    <xsd:element name="shell" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                                    <xsd:element name="shell" type="oval-def:EntityStateShellType" minOccurs="0" maxOccurs="1">
                                           <xsd:annotation>
                                                 <xsd:documentation>The 'shell' element contains the shell used to perform the command and must match the value in the associated object, verbatim.</xsd:documentation>
                                           </xsd:annotation>
@@ -1121,7 +1121,7 @@ A subexpression (using parentheses) can call out a piece of the matched stdout_l
                                                 <xsd:documentation>The subexpression entity represents a value to test against the subexpression in the specified pattern. If multiple subexpressions are specified in the pattern, this value is tested against all of them. For example, if the pattern abc(.*)mno(.*)xyp was supplied, and the state specifies a subexpression value of enabled, then the test would check that both (or at least one, none, etc. depending on the entity_check attribute) of the subexpressions have a value of enabled.</xsd:documentation>
                                           </xsd:annotation>
                                     </xsd:element>
-                                    <xsd:element name="stderr_line" type="oval-def:EntityStateAnySimpleType" minOccurs="0" maxOccurs="unbounded">
+                                    <xsd:element name="stderr_line" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="unbounded">
                                           <xsd:annotation>		
 												 <xsd:documentation>The 'stderr_line' element contains any and all output to STDERR from a run of the object command.  Each line of STDERR should create an additional 'stderr_line' element.</xsd:documentation>
                                           </xsd:annotation>
@@ -2682,6 +2682,11 @@ SERVERPROPERTY('IsClustered') AS [is_clustered]
                                     <xsd:documentation>The korn shell (ksh).</xsd:documentation>
                               </xsd:annotation>
                         </xsd:enumeration>
+                        <xsd:enumeration value="Zsh">
+                              <xsd:annotation>
+                                    <xsd:documentation>The Z shell (Zsh).</xsd:documentation>
+                              </xsd:annotation>
+                        </xsd:enumeration>
                         <xsd:enumeration value="cmd">
                               <xsd:annotation>
                                     <xsd:documentation>The Microsoft Windows command prompt (cmd).</xsd:documentation>
@@ -2724,6 +2729,11 @@ SERVERPROPERTY('IsClustered') AS [is_clustered]
                         <xsd:enumeration value="ksh">
                               <xsd:annotation>
                                     <xsd:documentation>The korn shell (ksh).</xsd:documentation>
+                              </xsd:annotation>
+                        </xsd:enumeration>
+                        <xsd:enumeration value="Zsh">
+                              <xsd:annotation>
+                                    <xsd:documentation>The Z shell (Zsh).</xsd:documentation>
                               </xsd:annotation>
                         </xsd:enumeration>
                         <xsd:enumeration value="cmd">

--- a/oval-schemas/independent-definitions-schema.xsd
+++ b/oval-schemas/independent-definitions-schema.xsd
@@ -968,15 +968,17 @@
                   </xsd:complexContent>
             </xsd:complexType>
       </xsd:element>
-	  
+
       <!-- =============================================================================== -->
       <!-- ============================  SHELLCOMMAND TEST  =============================== -->
       <!-- =============================================================================== -->
       <xsd:element name="shellcommand_test" substitutionGroup="oval-def:test">
             <xsd:annotation>
-                  <xsd:documentation>The shellcommand_test is used to check the values produced by the running of the command (or embedded script, not an external script file) found in the object 'command' element. It extends the standard TestType as defined in the oval-definitions-schema and one should refer to the TestType description for more information. The required object element references a shellcommand_object and the optional state element references a shellcommand_state that specifies the information to check.
+                  <xsd:documentation>The shellcommand_test is used to check the values produced by the running of the 'command' (or script, but not an external script file) found in the object 'command' element. It extends the standard TestType as defined in the oval-definitions-schema and one should refer to the TestType description for more information. The required object element references a shellcommand_object and the optional state element references a shellcommand_state that specifies the information to check.
+                  
+Since this test runs the command string supplied in the object command element, the content author should avoid writing command strings that may produce large amounts of output or that may be fragile causing errors and thus produce large amounts of error output.  The command should produce well formed output that will result in one OVAL item foreach line of output produced by the object evaluation.
                                    
-				Since this test requires the running of code supplied by content and since SCAP applications commonly run with elevated privileges, significant responsibilty falls to the content author to do no harm.  This also requires that any content stream that employs this test MUST be from a known trusted source and be digitally signed.  The use of any executables that are not supplied by the installed operating system is highly discouraged.</xsd:documentation>
+IMPORTANT! - Since this test requires the running of code supplied by content and since OVAL interpreters commonly run with elevated privileges, significant responsibilty falls to the content author to DO NO HARM to the target system.  This also requires that any content stream that employs this test MUST be from a known trusted source and be digitally signed.  The use of any executables that are not supplied by the installed operating system is highly discouraged.</xsd:documentation>
                   <xsd:appinfo>
                         <oval:element_mapping>
                               <oval:test>shellcommand_test</oval:test>
@@ -1010,7 +1012,13 @@
       
       <xsd:element name="shellcommand_object" substitutionGroup="oval-def:object">
             <xsd:annotation>
-                  <xsd:documentation>The shellcommand_object is used by a shellcommand_test to define a command (or shell script) to be run and a pattern to filter result lines. Each object extends the standard ObjectType as defined in the oval-definitions-schema and one should refer to the ObjectType description for more information. The common set element allows complex objects to be created using filters and set logic.</xsd:documentation>
+                  <xsd:documentation>The shellcommand_object is used by a shellcommand_test to define a shell to use (e.g. sh, bash, ksh, etc.), a command (or shell script) to be run, and a pattern to filter result lines. The default shell is bash.  Each object extends the standard ObjectType as defined in the oval-definitions-schema and one should refer to the ObjectType description for more information. The common set element allows complex objects to be created using filters and set logic.
+                  
+The evaluation of the object should always produce at least one item.  If the object evaluation does not produce output that should result in an item, one should be created with a status of 'does not exist' and, if possible, the exit_status and any STDERR from the system call should be captured in that item.
+
+Also, note that as lines from STDERR often cannot be related to a specific line of STDOUT, each item will contain all of the output from STDERR.  Content authors should be aware that this could be highly redundant and voluminous and should design object command strings accordingly.
+
+                  </xsd:documentation>
                   <xsd:appinfo>
                         <sch:pattern id="ind-def_shellcommand_object_verify_filter_state">
                               <sch:rule context="ind-def:shellcommand_object//oval-def:filter">
@@ -1032,21 +1040,22 @@
                                     <xsd:choice>
                                           <xsd:element ref="oval-def:set"/>
                                           <xsd:sequence>
-                                                <xsd:element name="shell" type="ind-def:EntityObjectShellType">
+                                                <xsd:element name="shell" type="oval-def:EntityObjectStringType">
                                                       <xsd:annotation>
-                                                            <xsd:documentation>The shell entity defines the specific shell interpreter to use. Any tool looking to collect information about this object will need to know the shell in order to use it properly.</xsd:documentation>
+                                                            <xsd:documentation>The shell entity defines the specific shell to use (e.g. bash, csh, ksh, etc.). Any tool collecting information for this object will need to know the shell in order to use it properly.</xsd:documentation>
                                                       </xsd:annotation>
                                                 </xsd:element>
                                                 <xsd:element name="command" type="oval-def:EntityObjectStringType"  minOccurs="1" maxOccurs="1">
                                                       <xsd:annotation>
-                                                            <xsd:documentation>The command element specifies the command string to be run on the target system.  Since this command or script will be executed on the target system and since SCAP applications commonly run with elevated privileges, significant responsibilty falls to the content author to do no harm.  This also requires that any content stream that employs this test MUST be from a known trusted source and be digitally signed.  The use of executables that are not supplied by the installed operating system is highly discouraged.</xsd:documentation>
+                                                            <xsd:documentation>The command element specifies the command string to be run on the target system.  Since this command string will be executed on the target system and since OVAL interpreters commonly run with elevated privileges, significant responsibilty falls to the content author to DO NO HARM.  This also requires that any content stream that employs this test MUST be from a known trusted source and be digitally signed.  The use of executables that are not supplied by the installed operating system is highly discouraged.</xsd:documentation>
                                                       </xsd:annotation>
                                                 </xsd:element>
                                                 <xsd:element name="pattern" type="oval-def:EntityObjectStringType"  minOccurs="0" maxOccurs="1">
                                                       <xsd:annotation>
                                                             <xsd:documentation>The 'pattern' is a regular expression that identifies lines in 'command' results that are to produce OVAL items.   Any result line that matches the pattern is kept as an OVAL item.  Any that do not are discarded.  If the pattern element is empty or does not exist, all results lines are kept.  
 															
-															A subexpression (using parentheses) can call out a piece of the matched stdout_line to test. For example, the pattern abc(.*)xyz would look for a block of text in the file that starts with abc and ends with xyz, with the subexpression being all the characters that exist in between. The value of the subexpression can then be tested using the subexpression entity of a shellcommand_state. Note that if the pattern, starting at the same point in the line, matches more than one block of text, then it matches the longest. For example, given a file with abcdefxyzxyzabc, then the pattern abc(.*)xyz would match the block abcdefxyzxyz. Subexpressions also match the longest possible substrings, subject to the constraint that the whole match be as long as possible, with subexpressions starting earlier in the pattern taking priority over ones starting later.
+A subexpression (using parentheses) can call out a piece of the matched stdout_line to test. For example, the pattern abc(.*)xyz would look for a block of text in the file that starts with abc and ends with xyz, with the subexpression being all the characters that exist in between. The value of the subexpression can then be tested using the subexpression entity of a shellcommand_state. Note that if the pattern, starting at the same point in the line, matches more than one block of text, then it matches the longest. For example, given a file with abcdefxyzxyzabc, then the pattern abc(.*)xyz would match the block abcdefxyzxyz. Subexpressions also match the longest possible substrings, subject to the constraint that the whole match be as long as possible, with subexpressions starting earlier in the pattern taking priority over ones starting later.
+
 															</xsd:documentation>
                                                             <xsd:documentation>Note that when using regular expressions, OVAL supports a common subset of the regular expression character classes, operations, expressions and other lexical tokens defined within Perl 5's regular expression specification. For more information on the supported regular expression syntax in OVAL see: http://oval.mitre.org/language/about/re_support_5.6.html.</xsd:documentation>
                                                             <xsd:appinfo>
@@ -1075,20 +1084,20 @@
                   <xsd:complexContent>
                         <xsd:extension base="oval-def:StateType">
                               <xsd:sequence>
-                                    <xsd:element name="shell" type="oval-def:EntityStateShellType" minOccurs="0" maxOccurs="1">
+                                    <xsd:element name="shell" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
                                           <xsd:annotation>
-                                                <xsd:documentation>The shell element contains the shell used to perform the command.</xsd:documentation>
+                                                <xsd:documentation>The 'shell' element contains the shell used to perform the command and must match the value in the associated object, verbatim.</xsd:documentation>
                                           </xsd:annotation>
                                     </xsd:element>
                                     
                                     <xsd:element name="command" type="oval-def:EntityStateAnySimpleType" minOccurs="1" maxOccurs="1">
                                           <xsd:annotation>
-                                                <xsd:documentation>The 'command' element specifies the command string to be run on the target system and must match, verbatim, the same element in the associated shellcommand_object.</xsd:documentation>
+                                                <xsd:documentation>The 'command' element specifies the command string to be run on the target system and must match the same element in the associated shellcommand_object, verbatim.</xsd:documentation>
                                           </xsd:annotation>
                                     </xsd:element>                                    
                                     <xsd:element name="pattern" type="oval-def:EntityStateStringType"  minOccurs="0" maxOccurs="1">
                                           <xsd:annotation>
-                                                <xsd:documentation>The 'pattern' is a regular expression that identifies lines in 'command' results that are to produce OVAL items and must match, verbatim, the same element in the associated shellcommand_object.</xsd:documentation>
+                                                <xsd:documentation>The 'pattern' is a regular expression that identifies lines in 'command' results that are to produce OVAL items and must match the same element in the associated shellcommand_object, verbatim.</xsd:documentation>
                                                 <xsd:appinfo>
                                                       <sch:pattern id="ind-def_txt54objpattern">
                                                             <sch:rule context="ind-def:textfilecontent54_state/ind-def:pattern">
@@ -1100,28 +1109,30 @@
                                     </xsd:element>
 			                        <xsd:element name="exit_status" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
 										<xsd:annotation>
-											<xsd:documentation>The exit_status entity represents the exist status returned by the system for the execution of the object command.</xsd:documentation>
+											<xsd:documentation>The 'exit_status' entity represents the exist status returned by the system for the execution of the object command.</xsd:documentation>
 										</xsd:annotation>
 									</xsd:element>
                                     <xsd:element name="stdout_line" type="oval-def:EntityStateAnySimpleType" minOccurs="0" maxOccurs="1">
                                           <xsd:annotation>
-                                                <xsd:documentation>The stdout_line entity represents a line from the STDOUT output of a successful run of the command string that matched the specified object pattern.</xsd:documentation>
+                                                <xsd:documentation>The 'stdout_line' entity represents a line from the STDOUT output of a successful run of the command string that matched the specified object pattern.</xsd:documentation>
                                           </xsd:annotation>
                                     </xsd:element>
-                                    <xsd:element name="stderr_line" type="oval-def:EntityStateAnySimpleType" minOccurs="0" maxOccurs="1">
+                                    <xsd:element name="subexpression" type="oval-def:EntityStateAnySimpleType" minOccurs="0" maxOccurs="1">
                                           <xsd:annotation>
-                                                <xsd:documentation>The stderr_line element represents a line from the STDERR output of a run of the command string that matched the specified object pattern.  Each line of STDERR produced by the command execution will produce a single shellcommand item.</xsd:documentation>
-					<!-- WHICH ONE????? -->		
-												 <xsd:documentation>The stderr(_line) element contains any output to STDERR from a run of the object command.</xsd:documentation>
+                                                <xsd:documentation>The subexpression entity represents a value to test against the subexpression in the specified pattern. If multiple subexpressions are specified in the pattern, this value is tested against all of them. For example, if the pattern abc(.*)mno(.*)xyp was supplied, and the state specifies a subexpression value of enabled, then the test would check that both (or at least one, none, etc. depending on the entity_check attribute) of the subexpressions have a value of enabled.</xsd:documentation>
                                           </xsd:annotation>
                                     </xsd:element>
-
+                                    <xsd:element name="stderr" type="oval-def:EntityStateAnySimpleType" minOccurs="0" maxOccurs="1">
+                                          <xsd:annotation>		
+												 <xsd:documentation>The 'stderr' element contains any and all output to STDERR from a run of the object command.</xsd:documentation>
+                                          </xsd:annotation>
+                                    </xsd:element>
                               </xsd:sequence>
                         </xsd:extension>
                   </xsd:complexContent>
             </xsd:complexType>
       </xsd:element>
-	  
+	 
 	  
       <!-- =============================================================================== -->
       <!-- =================================  SQL TEST  ================================== -->

--- a/oval-schemas/independent-definitions-schema.xsd
+++ b/oval-schemas/independent-definitions-schema.xsd
@@ -976,7 +976,9 @@
             <xsd:annotation>
                   <xsd:documentation>The shellcommand_test is used to check the values produced by the running of the 'command' (or script, but not an external script file) found in the object 'command' element. It extends the standard TestType as defined in the oval-definitions-schema and one should refer to the TestType description for more information. The required object element references a shellcommand_object and the optional state element references a shellcommand_state that specifies the information to check.
                   
-Since this test runs the command string supplied in the object command element, the content author should avoid writing command strings that may produce large amounts of output or that may be fragile causing errors and thus produce large amounts of error output.  The command should produce well formed output that will result in one OVAL item foreach line of output produced by the object evaluation.
+Since this test runs the command string supplied in the object command element, the content author should avoid writing command strings that may produce large amounts of output or that may be fragile causing errors and thus produce large amounts of error output.
+
+The command should produce well formed output that will result in one item stdout_line element for each line of output via STDOUT by the object evaluation.  Similarly, in the item, for any output to STDERR, a stderr_line element will be created.
                                    
 IMPORTANT! - Since this test requires the running of code supplied by content and since OVAL interpreters commonly run with elevated privileges, significant responsibilty falls to the content author to DO NO HARM to the target system.  This also requires that any content stream that employs this test MUST be from a known trusted source and be digitally signed.  The use of any executables that are not supplied by the installed operating system is highly discouraged.</xsd:documentation>
                   <xsd:appinfo>
@@ -1015,9 +1017,6 @@ IMPORTANT! - Since this test requires the running of code supplied by content an
                   <xsd:documentation>The shellcommand_object is used by a shellcommand_test to define a shell to use (e.g. sh, bash, ksh, etc.), a command (or shell script) to be run, and a pattern to filter result lines. The default shell is bash.  Each object extends the standard ObjectType as defined in the oval-definitions-schema and one should refer to the ObjectType description for more information. The common set element allows complex objects to be created using filters and set logic.
                   
 The evaluation of the object should always produce at least one item.  If the object evaluation does not produce output that should result in an item, one should be created with a status of 'does not exist' and, if possible, the exit_status and any STDERR from the system call should be captured in that item.
-
-Also, note that as lines from STDERR often cannot be related to a specific line of STDOUT, each item will contain all of the output from STDERR.  Content authors should be aware that this could be highly redundant and voluminous and should design object command strings accordingly.
-
                   </xsd:documentation>
                   <xsd:appinfo>
                         <sch:pattern id="ind-def_shellcommand_object_verify_filter_state">
@@ -1052,7 +1051,7 @@ Also, note that as lines from STDERR often cannot be related to a specific line 
                                                 </xsd:element>
                                                 <xsd:element name="pattern" type="oval-def:EntityObjectStringType"  minOccurs="0" maxOccurs="1">
                                                       <xsd:annotation>
-                                                            <xsd:documentation>The 'pattern' is a regular expression that identifies lines in 'command' results that are to produce OVAL items.   Any result line that matches the pattern is kept as an OVAL item.  Any that do not are discarded.  If the pattern element is empty or does not exist, all results lines are kept.  
+                                                            <xsd:documentation>The 'pattern' is a regular expression that identifies lines in 'command' results that are to produce OVAL items.   Any result line via STDOUT that matches the pattern is kept as an item stdout_line element.  Any that do not are discarded.  If the pattern element is empty or does not exist, all results lines are kept.  
 															
 A subexpression (using parentheses) can call out a piece of the matched stdout_line to test. For example, the pattern abc(.*)xyz would look for a block of text in the file that starts with abc and ends with xyz, with the subexpression being all the characters that exist in between. The value of the subexpression can then be tested using the subexpression entity of a shellcommand_state. Note that if the pattern, starting at the same point in the line, matches more than one block of text, then it matches the longest. For example, given a file with abcdefxyzxyzabc, then the pattern abc(.*)xyz would match the block abcdefxyzxyz. Subexpressions also match the longest possible substrings, subject to the constraint that the whole match be as long as possible, with subexpressions starting earlier in the pattern taking priority over ones starting later.
 
@@ -1112,7 +1111,7 @@ A subexpression (using parentheses) can call out a piece of the matched stdout_l
 											<xsd:documentation>The 'exit_status' entity represents the exist status returned by the system for the execution of the object command.</xsd:documentation>
 										</xsd:annotation>
 									</xsd:element>
-                                    <xsd:element name="stdout_line" type="oval-def:EntityStateAnySimpleType" minOccurs="0" maxOccurs="1">
+                                    <xsd:element name="stdout_line" type="oval-def:EntityStateAnySimpleType" minOccurs="0" maxOccurs="unbounded">
                                           <xsd:annotation>
                                                 <xsd:documentation>The 'stdout_line' entity represents a line from the STDOUT output of a successful run of the command string that matched the specified object pattern.</xsd:documentation>
                                           </xsd:annotation>
@@ -1122,9 +1121,9 @@ A subexpression (using parentheses) can call out a piece of the matched stdout_l
                                                 <xsd:documentation>The subexpression entity represents a value to test against the subexpression in the specified pattern. If multiple subexpressions are specified in the pattern, this value is tested against all of them. For example, if the pattern abc(.*)mno(.*)xyp was supplied, and the state specifies a subexpression value of enabled, then the test would check that both (or at least one, none, etc. depending on the entity_check attribute) of the subexpressions have a value of enabled.</xsd:documentation>
                                           </xsd:annotation>
                                     </xsd:element>
-                                    <xsd:element name="stderr" type="oval-def:EntityStateAnySimpleType" minOccurs="0" maxOccurs="1">
+                                    <xsd:element name="stderr_line" type="oval-def:EntityStateAnySimpleType" minOccurs="0" maxOccurs="unbounded">
                                           <xsd:annotation>		
-												 <xsd:documentation>The 'stderr' element contains any and all output to STDERR from a run of the object command.</xsd:documentation>
+												 <xsd:documentation>The 'stderr_line' element contains any and all output to STDERR from a run of the object command.  Each line of STDERR should create an additional 'stderr_line' element.</xsd:documentation>
                                           </xsd:annotation>
                                     </xsd:element>
                               </xsd:sequence>

--- a/oval-schemas/independent-definitions-schema.xsd
+++ b/oval-schemas/independent-definitions-schema.xsd
@@ -1016,8 +1016,8 @@ IMPORTANT! - Since this test requires the running of code supplied by content an
             <xsd:annotation>
                   <xsd:documentation>The shellcommand_object is used by a shellcommand_test to define a shell to use (e.g. sh, bash, ksh, etc.), a command (or shell script) to be run, and a pattern to filter result lines. The default shell is bash.  Each object extends the standard ObjectType as defined in the oval-definitions-schema and one should refer to the ObjectType description for more information. The common set element allows complex objects to be created using filters and set logic.
                   
-The evaluation of the object should always produce at least one item.  If the object evaluation does not produce output that should result in an item, one should be created with a status of 'does not exist' and, if possible, the exit_status and any STDERR from the system call should be captured in that item.
-                  </xsd:documentation>
+The evaluation of the object should always produce one item. If the command execution does not produce output, an item should still be created with the exit_status (AKA process exit code), a stdout entity with a status of 'does not exist', and any STDERR from the execution captured in stderr_line entities.                  
+				  </xsd:documentation>
                   <xsd:appinfo>
                         <sch:pattern id="ind-def_shellcommand_object_verify_filter_state">
                               <sch:rule context="ind-def:shellcommand_object//oval-def:filter">

--- a/oval-schemas/independent-system-characteristics-schema.xsd
+++ b/oval-schemas/independent-system-characteristics-schema.xsd
@@ -325,18 +325,22 @@
                </xsd:complexContent>
           </xsd:complexType>
      </xsd:element>
+
+	
 	 <!-- =============================================================================== -->
      <!-- ==========================  SHELLCOMMAND ITEM  ================================= -->
      <!-- =============================================================================== -->
      <xsd:element name="shellcommand_item" substitutionGroup="oval-sc:item">
           <xsd:annotation>
-               <xsd:documentation>The shellcommand_item stores information retrieved from the local system that results from the running of the command or embedded script in the associated object command element.</xsd:documentation>
+               <xsd:documentation>The shellcommand_item stores information retrieved from the local system that results from the running of the command or embedded script in the associated object command element.
+               
+The evaluation of the object should always produce at least one item.  If the object evaluation does not produce output that should result in an item, one should be created with a status of 'does not exist'.  This facilitates that capture of the exit_status and stderr from the system call.</xsd:documentation>
           </xsd:annotation>
           <xsd:complexType>
                <xsd:complexContent>
                     <xsd:extension base="oval-sc:ItemType">
                          <xsd:sequence>
-                              <xsd:element name="shell" type="oval-sc:EntityItemShellType" minOccurs="1" maxOccurs="1">
+                              <xsd:element name="shell" type="oval-sc:EntityItemStringType" minOccurs="1" maxOccurs="1">
                                    <xsd:annotation>
                                         <xsd:documentation>The shell element contains the shell used (e.g. bash or powershell) to perform the command and should be taken, verbatim, from the associated object 'shell' element.</xsd:documentation>
                                    </xsd:annotation>
@@ -362,11 +366,14 @@
 									<xsd:documentation>The stdout_line entity contains a line from the STDOUT output of a successful run of the command string that matched the specified object pattern.  Each line created by the execution of the object command should create an item.</xsd:documentation>
 								</xsd:annotation>
 							</xsd:element>
-							<xsd:element name="stderr_line" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="unbounded">
+                            <xsd:element name="subexpression" type="oval-sc:EntityItemAnySimpleType" minOccurs="0" maxOccurs="unbounded">
+                                   <xsd:annotation>
+                                        <xsd:documentation>The subexpression entity represents the value of a subexpression in the specified pattern.  If multiple subexpressions are specified in the pattern, then multiple entities are presented.  Note that the textfilecontent_state in the definition schema only allows a single subexpression entity.  This means that the test will check that all (or at least one, none, etc.) the subexpressions pass the same check.  This means that the order of multiple subexpression entities in the item does not matter.</xsd:documentation>
+                                   </xsd:annotation>
+                               </xsd:element>
+							<xsd:element name="stderr" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="unbounded">
 								<xsd:annotation>
-									<xsd:documentation>The stderr_line element represents a line from the STDERR output of a run of the command string that matched the specified object pattern.  Each line of STDERR produced by the command execution will produce a single shellcommand item.</xsd:documentation>
-												
-									<xsd:documentation>The stderr_line element represents any and all output to STDERR from a run of the command string.</xsd:documentation>
+									<xsd:documentation>The stderr element represents any and all output to STDERR from a run of the command string.</xsd:documentation>
 								</xsd:annotation>
 							</xsd:element>
                          </xsd:sequence>

--- a/oval-schemas/independent-system-characteristics-schema.xsd
+++ b/oval-schemas/independent-system-characteristics-schema.xsd
@@ -330,7 +330,7 @@
      <!-- =============================================================================== -->
      <xsd:element name="shellcommand_item" substitutionGroup="oval-sc:item">
           <xsd:annotation>
-               <xsd:documentation>The shellcommand_item stores information retrieved from the local system that result from the running of the command or embedded script in the associated object command element.</xsd:documentation>
+               <xsd:documentation>The shellcommand_item stores information retrieved from the local system that results from the running of the command or embedded script in the associated object command element.</xsd:documentation>
           </xsd:annotation>
           <xsd:complexType>
                <xsd:complexContent>
@@ -338,7 +338,7 @@
                          <xsd:sequence>
                               <xsd:element name="shell" type="oval-sc:EntityItemShellType" minOccurs="1" maxOccurs="1">
                                    <xsd:annotation>
-                                        <xsd:documentation>The shell element contains the shell used to perform the command.</xsd:documentation>
+                                        <xsd:documentation>The shell element contains the shell used (e.g. bash or powershell) to perform the command and should be taken, verbatim, from the associated object 'shell' element.</xsd:documentation>
                                    </xsd:annotation>
                               </xsd:element>
                               <xsd:element name="command" type="oval-sc::EntityItemStringType"  minOccurs="1" maxOccurs="1">
@@ -354,17 +354,19 @@
                               </xsd:element>                              
 							<xsd:element name="exit_status" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
 								<xsd:annotation>
-									<xsd:documentation>The exit status value from the command</xsd:documentation>
+									<xsd:documentation>The exit_status entity represents the exist status returned by the system for the execution of the object command. OVAL Item status should match the exit status of the system call.</xsd:documentation>
 								</xsd:annotation>
 							</xsd:element>
 							<xsd:element name="stdout_line" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="unbounded">
 								<xsd:annotation>
-									<xsd:documentation>Each line of standard output from the shell command which matches the line selection</xsd:documentation>
+									<xsd:documentation>The stdout_line entity contains a line from the STDOUT output of a successful run of the command string that matched the specified object pattern.  Each line created by the execution of the object command should create an item.</xsd:documentation>
 								</xsd:annotation>
 							</xsd:element>
 							<xsd:element name="stderr_line" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="unbounded">
 								<xsd:annotation>
-									<xsd:documentation>Each line of standard error output from the shell command.  All standard error lines are always included in any shellcommand_item generated.</xsd:documentation>
+									<xsd:documentation>The stderr_line element represents a line from the STDERR output of a run of the command string that matched the specified object pattern.  Each line of STDERR produced by the command execution will produce a single shellcommand item.</xsd:documentation>
+												
+									<xsd:documentation>The stderr_line element represents any and all output to STDERR from a run of the command string.</xsd:documentation>
 								</xsd:annotation>
 							</xsd:element>
                          </xsd:sequence>

--- a/oval-schemas/independent-system-characteristics-schema.xsd
+++ b/oval-schemas/independent-system-characteristics-schema.xsd
@@ -334,7 +334,7 @@
           <xsd:annotation>
                <xsd:documentation>The shellcommand_item stores information retrieved from the local system that results from the running of the command or embedded script in the associated object command element.
                
-The evaluation of the object should always produce at least one item.  If the object evaluation does not produce output that should result in an item, one should be created with a status of 'does not exist'.  This facilitates that capture of the exit_status and stderr from the system call.</xsd:documentation>
+The evaluation of the object should always produce at least one item.  If the object evaluation does not produce output via STDOUT that should result in an item, one should be created with a status of 'does not exist'.  This facilitates that capture of the exit_status and stderr from the system call.</xsd:documentation>
           </xsd:annotation>
           <xsd:complexType>
                <xsd:complexContent>
@@ -356,14 +356,14 @@ The evaluation of the object should always produce at least one item.  If the ob
                                         <xsd:documentation>The pattern element is simply an echo of the same element in the OVAL object and is supplied in the item to aid in end user interpretation and should be taken, verbatim, from the associated object 'pattern' element..</xsd:documentation>
                                    </xsd:annotation>
                               </xsd:element>                              
-							<xsd:element name="exit_status" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
+							<xsd:element name="exit_status" type="oval-sc:EntityItemIntType" minOccurs="1" maxOccurs="1">
 								<xsd:annotation>
 									<xsd:documentation>The exit_status entity represents the exist status returned by the system for the execution of the object command. OVAL Item status should match the exit status of the system call.</xsd:documentation>
 								</xsd:annotation>
 							</xsd:element>
 							<xsd:element name="stdout_line" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="unbounded">
 								<xsd:annotation>
-									<xsd:documentation>The stdout_line entity contains a line from the STDOUT output of a successful run of the command string that matched the specified object pattern.  Each line created by the execution of the object command should create an item.</xsd:documentation>
+									<xsd:documentation>The stdout_line entity contains a line from the STDOUT output of a successful run of the command string that matched the specified object pattern.  Each line created by the execution of the object command should create an item 'stdout_line' element.</xsd:documentation>
 								</xsd:annotation>
 							</xsd:element>
                             <xsd:element name="subexpression" type="oval-sc:EntityItemAnySimpleType" minOccurs="0" maxOccurs="unbounded">
@@ -371,9 +371,9 @@ The evaluation of the object should always produce at least one item.  If the ob
                                         <xsd:documentation>The subexpression entity represents the value of a subexpression in the specified pattern.  If multiple subexpressions are specified in the pattern, then multiple entities are presented.  Note that the textfilecontent_state in the definition schema only allows a single subexpression entity.  This means that the test will check that all (or at least one, none, etc.) the subexpressions pass the same check.  This means that the order of multiple subexpression entities in the item does not matter.</xsd:documentation>
                                    </xsd:annotation>
                                </xsd:element>
-							<xsd:element name="stderr" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="unbounded">
+							<xsd:element name="stderr_line" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="unbounded">
 								<xsd:annotation>
-									<xsd:documentation>The stderr element represents any and all output to STDERR from a run of the command string.</xsd:documentation>
+									<xsd:documentation>The 'stderr_line' element contains a single line of any output from STDERR.</xsd:documentation>
 								</xsd:annotation>
 							</xsd:element>
                          </xsd:sequence>

--- a/oval-schemas/independent-system-characteristics-schema.xsd
+++ b/oval-schemas/independent-system-characteristics-schema.xsd
@@ -334,13 +334,13 @@
           <xsd:annotation>
                <xsd:documentation>The shellcommand_item stores information retrieved from the local system that results from the running of the command or embedded script in the associated object command element.
                
-The evaluation of the object should always produce at least one item.  If the object evaluation does not produce output via STDOUT that should result in an item, one should be created with a status of 'does not exist'.  This facilitates that capture of the exit_status and stderr from the system call.</xsd:documentation>
+The evaluation of the object should always produce one item.  If the object evaluation does not produce output via STDOUT that should result in an item, one should be created with a status of 'does not exist'.  This facilitates that capture of the exit_status and stderr from the system call.</xsd:documentation>
           </xsd:annotation>
           <xsd:complexType>
                <xsd:complexContent>
                     <xsd:extension base="oval-sc:ItemType">
                          <xsd:sequence>
-                              <xsd:element name="shell" type="oval-sc:EntityItemStringType" minOccurs="1" maxOccurs="1">
+                              <xsd:element name="shell" type="oval-sc:EntityItemShellType" minOccurs="1" maxOccurs="1">
                                    <xsd:annotation>
                                         <xsd:documentation>The shell element contains the shell used (e.g. bash or powershell) to perform the command and should be taken, verbatim, from the associated object 'shell' element.</xsd:documentation>
                                    </xsd:annotation>
@@ -788,6 +788,11 @@ The evaluation of the object should always produce at least one item.  If the ob
                         <xsd:enumeration value="ksh">
                               <xsd:annotation>
                                     <xsd:documentation>The korn shell (ksh).</xsd:documentation>
+                              </xsd:annotation>
+                        </xsd:enumeration>
+                        <xsd:enumeration value="Zsh">
+                              <xsd:annotation>
+                                    <xsd:documentation>The Z shell (Zsh).</xsd:documentation>
                               </xsd:annotation>
                         </xsd:enumeration>
                         <xsd:enumeration value="cmd">

--- a/oval-schemas/independent-system-characteristics-schema.xsd
+++ b/oval-schemas/independent-system-characteristics-schema.xsd
@@ -790,9 +790,9 @@ The evaluation of the object should always produce one item.  If the object eval
                                     <xsd:documentation>The korn shell (ksh).</xsd:documentation>
                               </xsd:annotation>
                         </xsd:enumeration>
-                        <xsd:enumeration value="Zsh">
+                        <xsd:enumeration value="zsh">
                               <xsd:annotation>
-                                    <xsd:documentation>The Z shell (Zsh).</xsd:documentation>
+                                    <xsd:documentation>The Z shell (zsh).</xsd:documentation>
                               </xsd:annotation>
                         </xsd:enumeration>
                         <xsd:enumeration value="cmd">

--- a/oval-schemas/independent-system-characteristics-schema.xsd
+++ b/oval-schemas/independent-system-characteristics-schema.xsd
@@ -325,6 +325,55 @@
                </xsd:complexContent>
           </xsd:complexType>
      </xsd:element>
+	 <!-- =============================================================================== -->
+     <!-- ==========================  SHELLCOMMAND ITEM  ================================= -->
+     <!-- =============================================================================== -->
+     <xsd:element name="shellcommand_item" substitutionGroup="oval-sc:item">
+          <xsd:annotation>
+               <xsd:documentation>The shellcommand_item stores information retrieved from the local system that result from the running of the command or embedded script in the associated object command element.</xsd:documentation>
+          </xsd:annotation>
+          <xsd:complexType>
+               <xsd:complexContent>
+                    <xsd:extension base="oval-sc:ItemType">
+                         <xsd:sequence>
+                              <xsd:element name="shell" type="oval-sc:EntityItemShellType" minOccurs="1" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>The shell element contains the shell used to perform the command.</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>
+                              <xsd:element name="command" type="oval-sc::EntityItemStringType"  minOccurs="1" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>The command element specifies the command string that was run on the target system and should be taken, verbatim, from the associated object 'command' element..</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>                              
+                              
+                              <xsd:element name="pattern" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                                   <xsd:annotation>
+                                        <xsd:documentation>The pattern element is simply an echo of the same element in the OVAL object and is supplied in the item to aid in end user interpretation and should be taken, verbatim, from the associated object 'pattern' element..</xsd:documentation>
+                                   </xsd:annotation>
+                              </xsd:element>                              
+							<xsd:element name="exit_status" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
+								<xsd:annotation>
+									<xsd:documentation>The exit status value from the command</xsd:documentation>
+								</xsd:annotation>
+							</xsd:element>
+							<xsd:element name="stdout_line" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="unbounded">
+								<xsd:annotation>
+									<xsd:documentation>Each line of standard output from the shell command which matches the line selection</xsd:documentation>
+								</xsd:annotation>
+							</xsd:element>
+							<xsd:element name="stderr_line" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="unbounded">
+								<xsd:annotation>
+									<xsd:documentation>Each line of standard error output from the shell command.  All standard error lines are always included in any shellcommand_item generated.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:element>
+                         </xsd:sequence>
+                    </xsd:extension>
+               </xsd:complexContent>
+          </xsd:complexType>
+     </xsd:element>
+
+
      <!-- =============================================================================== -->
      <!-- =============================  SQL CONTENT ITEM   ============================= -->
      <!-- =============================================================================== -->
@@ -702,6 +751,59 @@
                </xsd:complexContent>
           </xsd:complexType>
      </xsd:element>
+     <!-- =============================================================================== -->
+     <!-- =============================================================================== -->
+     <!-- =============================================================================== -->	 
+	 
+	 <xsd:complexType name="EntityItemShellType">
+		  <xsd:annotation>
+               <xsd:documentation>The EntityItemShellType restricts a string value to a specific set of shell commands. The empty string is also allowed to support empty elements associated with error conditions.</xsd:documentation>
+          </xsd:annotation>
+          <xsd:simpleContent>
+               <xsd:restriction base="oval-sc:EntityItemStringType">
+                        <xsd:enumeration value="sh">
+                              <xsd:annotation>
+                                    <xsd:documentation>The borne shell (sh)</xsd:documentation>
+                              </xsd:annotation>
+                        </xsd:enumeration>
+                        <xsd:enumeration value="bash">
+                              <xsd:annotation>
+                                    <xsd:documentation>The gnu borne again shell (bash).</xsd:documentation>
+                              </xsd:annotation>
+                        </xsd:enumeration>
+                        <xsd:enumeration value="csh">
+                              <xsd:annotation>
+                                    <xsd:documentation>The C shell (csh).</xsd:documentation>
+                              </xsd:annotation>
+                        </xsd:enumeration>
+                        <xsd:enumeration value="ksh">
+                              <xsd:annotation>
+                                    <xsd:documentation>The korn shell (ksh).</xsd:documentation>
+                              </xsd:annotation>
+                        </xsd:enumeration>
+                        <xsd:enumeration value="cmd">
+                              <xsd:annotation>
+                                    <xsd:documentation>The Microsoft Windows command prompt (cmd).</xsd:documentation>
+                              </xsd:annotation>
+                        </xsd:enumeration>
+                        <xsd:enumeration value="powershell">
+                              <xsd:annotation>
+                                    <xsd:documentation>The Microsoft Powershell prompt (powershell).</xsd:documentation>
+                              </xsd:annotation>
+                        </xsd:enumeration>
+                        <xsd:enumeration value="">
+                              <xsd:annotation>
+                                    <xsd:documentation>The empty string value is permitted here to allow for empty elements associated with variable references.</xsd:documentation>
+                              </xsd:annotation>
+                        </xsd:enumeration>
+                    <xsd:enumeration value="">
+                         <xsd:annotation>
+                              <xsd:documentation>The empty string value is permitted here to allow for detailed error reporting.</xsd:documentation>
+                         </xsd:annotation>
+                    </xsd:enumeration>
+               </xsd:restriction>
+          </xsd:simpleContent>
+     </xsd:complexType>
      <!-- =============================================================================== -->
      <!-- =============================================================================== -->
      <!-- =============================================================================== -->


### PR DESCRIPTION
This pull request adds the capability discussed in #150 