### PR TITLE
Fixed readthedocs cross wiring of unix/windows tests that have the same name

### DIFF
--- a/guidelines/oval-schema-documentation/unix-definitions-schema.rst
+++ b/guidelines/oval-schema-documentation/unix-definitions-schema.rst
@@ -10,18 +10,18 @@ The OVAL Schema is maintained by the OVAL Community. For more information, inclu
 
 Test Listing  
 ---------------------------------------------------------
-* :ref:`dnscache_test` (Deprecated)  
+* :ref:`dnscache_test` 
 * :ref:`file_test`  
-* :ref:`fileextendedattribute_test` (Deprecated)  
-* :ref:`gconf_test` (Deprecated)  
-* :ref:`inetd_test` (Deprecated)  
+* :ref:`fileextendedattribute_test`  
+* :ref:`gconf_test` 
+* :ref:`inetd_test` 
 * :ref:`interface_test`  
 * :ref:`password_test`  
-* :ref:`process_test` (Deprecated)  
+* :ref:`process_test`   
 * :ref:`process58_test`  
-* :ref:`routingtable_test` (Deprecated)  
+* :ref:`routingtable_test` 
 * :ref:`runlevel_test`  
-* :ref:`sccs_test` (Deprecated)  
+* :ref:`sccs_test` 
 * :ref:`shadow_test`  
 * :ref:`sshd_test`  
 * :ref:`symlink_test`  
@@ -33,7 +33,7 @@ ______________
   
 .. _dnscache_test:  
   
-< dnscache_test > (Deprecated)  
+< dnscache_test > (unix) (Deprecated)  
 ---------------------------------------------------------
 Deprecation Info  
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -113,7 +113,7 @@ ______________
   
 .. _file_test:  
   
-< file_test >  
+< file_test >  (unix)
 ---------------------------------------------------------
 The file test is used to check metadata associated with UNIX files, of the sort returned by either an ls command, stat command or stat() system call. It extends the standard TestType as defined in the oval-definitions-schema and one should refer to the TestType description for more information. The required object element references a file_object and the optional state element specifies the metadata to check.
 
@@ -598,7 +598,7 @@ ______________
   
 .. _interface_test:  
   
-< interface_test >  
+< interface_test >  (unix)
 ---------------------------------------------------------
 The interface test enumerates various attributes about the interfaces on a system. It extends the standard TestType as defined in the oval-definitions-schema and one should refer to the TestType description for more information. The required object element references an interface_object and the optional state element specifies the interface information to check.
 
@@ -781,7 +781,7 @@ ______________
   
 .. _process_test:  
   
-< process_test > (Deprecated)  
+< process_test > (unix) (Deprecated)  
 ---------------------------------------------------------
 Deprecation Info  
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -890,7 +890,7 @@ ______________
   
 .. _process58_test:  
   
-< process58_test >  
+< process58_test >  (unix)
 ---------------------------------------------------------
 The process58_test is used to check information found in the UNIX processes. It is equivalent to parsing the output of the ps command. It extends the standard TestType as defined in the oval-definitions-schema and one should refer to the TestType description for more information. The required object element references a process58_object and the optional state element references a process58_state that specifies the process information to check.
 

--- a/guidelines/oval-schema-documentation/unix-definitions-schema.rst
+++ b/guidelines/oval-schema-documentation/unix-definitions-schema.rst
@@ -10,7 +10,7 @@ The OVAL Schema is maintained by the OVAL Community. For more information, inclu
 
 Test Listing  
 ---------------------------------------------------------
-* :ref:`dnscache_test` 
+* :ref:`dnscache_test_unix` 
 * :ref:`file_test`  
 * :ref:`fileextendedattribute_test`  
 * :ref:`gconf_test` 
@@ -31,7 +31,7 @@ Test Listing
   
 ______________
   
-.. _dnscache_test:  
+.. _dnscache_test_unix:  
   
 < dnscache_test > (unix) (Deprecated)  
 ---------------------------------------------------------

--- a/guidelines/oval-schema-documentation/unix-definitions-schema.rst
+++ b/guidelines/oval-schema-documentation/unix-definitions-schema.rst
@@ -11,14 +11,14 @@ The OVAL Schema is maintained by the OVAL Community. For more information, inclu
 Test Listing  
 ---------------------------------------------------------
 * :ref:`dnscache_test_unix` 
-* :ref:`file_test`  
+* :ref:`file_test_unix`  
 * :ref:`fileextendedattribute_test`  
 * :ref:`gconf_test` 
 * :ref:`inetd_test` 
 * :ref:`interface_test`  
 * :ref:`password_test`  
-* :ref:`process_test`   
-* :ref:`process58_test`  
+* :ref:`process_test_unix`   
+* :ref:`process58_test_unix`  
 * :ref:`routingtable_test` 
 * :ref:`runlevel_test`  
 * :ref:`sccs_test` 
@@ -111,7 +111,7 @@ Child Elements
   
 ______________
   
-.. _file_test:  
+.. _file_test_unix:  
   
 < file_test >  (unix)
 ---------------------------------------------------------
@@ -779,7 +779,7 @@ Child Elements
   
 ______________
   
-.. _process_test:  
+.. _process_test_unix:  
   
 < process_test > (unix) (Deprecated)  
 ---------------------------------------------------------
@@ -888,7 +888,7 @@ Child Elements
   
 ______________
   
-.. _process58_test:  
+.. _process58_test_unix:  
   
 < process58_test >  (unix)
 ---------------------------------------------------------

--- a/guidelines/oval-schema-documentation/windows-definitions-schema.rst
+++ b/guidelines/oval-schema-documentation/windows-definitions-schema.rst
@@ -10,56 +10,56 @@ The OVAL Schema is maintained by the OVAL Community. For more information, inclu
 
 Test Listing  
 ---------------------------------------------------------
-* :ref:`accesstoken_test` (Deprecated)  
-* :ref:`activedirectory_test` (Deprecated)  
-* :ref:`activedirectory57_test` (Deprecated)  
-* :ref:`auditeventpolicy_test` (Deprecated)  
+* :ref:`accesstoken_test`  
+* :ref:`activedirectory_test` 
+* :ref:`activedirectory57_test`  
+* :ref:`auditeventpolicy_test` 
 * :ref:`auditeventpolicysubcategories_test`  
 * :ref:`cmdlet_test`  
-* :ref:`dnscache_test` (Deprecated)  
+* :ref:`dnscache_test`   
 * :ref:`file_test`  
-* :ref:`fileauditedpermissions53_test` (Deprecated)  
-* :ref:`fileauditedpermissions_test` (Deprecated)  
+* :ref:`fileauditedpermissions53_test`  
+* :ref:`fileauditedpermissions_test`  
 * :ref:`fileeffectiverights53_test`  
-* :ref:`fileeffectiverights_test` (Deprecated)  
-* :ref:`group_test` (Deprecated)  
+* :ref:`fileeffectiverights_test`   
+* :ref:`group_test`  
 * :ref:`group_sid_test`  
-* :ref:`interface_test` (Deprecated)  
-* :ref:`junction_test` (Deprecated)  
-* :ref:`license_test` (Deprecated)  
+* :ref:`interface_test`   
+* :ref:`junction_test`  
+* :ref:`license_test`   
 * :ref:`lockoutpolicy_test`  
-* :ref:`metabase_test` (Deprecated)  
+* :ref:`metabase_test` 
 * :ref:`ntuser_test`  
 * :ref:`passwordpolicy_test`  
-* :ref:`peheader_test` (Deprecated)  
-* :ref:`port_test` (Deprecated)  
-* :ref:`printereffectiverights_test` (Deprecated)  
-* :ref:`process_test` (Deprecated)  
-* :ref:`process58_test` (Deprecated)  
+* :ref:`peheader_test` 
+* :ref:`port_test` 
+* :ref:`printereffectiverights_test`
+* :ref:`process_test`  
+* :ref:`process58_test` 
 * :ref:`registry_test`  
-* :ref:`regkeyauditedpermissions53_test` (Deprecated)  
-* :ref:`regkeyauditedpermissions_test` (Deprecated)  
+* :ref:`regkeyauditedpermissions53_test`  
+* :ref:`regkeyauditedpermissions_test` 
 * :ref:`regkeyeffectiverights53_test`  
-* :ref:`regkeyeffectiverights_test` (Deprecated)  
+* :ref:`regkeyeffectiverights_test`   
 * :ref:`service_test`  
-* :ref:`serviceeffectiverights_test` (Deprecated)  
-* :ref:`sharedresource_test` (Deprecated)  
-* :ref:`sharedresourceauditedpermissions_test` (Deprecated)  
-* :ref:`sharedresourceeffectiverights_test` (Deprecated)  
+* :ref:`serviceeffectiverights_test` 
+* :ref:`sharedresource_test`  
+* :ref:`sharedresourceauditedpermissions_test`  
+* :ref:`sharedresourceeffectiverights_test`   
 * :ref:`sid_test`  
 * :ref:`sid_sid_test`  
-* :ref:`systemmetric_test` (Deprecated)  
-* :ref:`uac_test` (Deprecated)  
-* :ref:`user_test` (Deprecated)  
+* :ref:`systemmetric_test` 
+* :ref:`uac_test`  
+* :ref:`user_test` 
 * :ref:`user_sid55_test`  
-* :ref:`user_sid_test` (Deprecated)  
+* :ref:`user_sid_test`  
 * :ref:`userright_test`  
 * :ref:`appcmd_test`  
 * :ref:`appcmdlistconfig_test`  
-* :ref:`volume_test` (Deprecated)  
-* :ref:`wmi_test` (Deprecated)  
+* :ref:`volume_test` 
+* :ref:`wmi_test` 
 * :ref:`wmi57_test`  
-* :ref:`wuaupdatesearcher_test` (Deprecated)  
+* :ref:`wuaupdatesearcher_test` 
   
 ______________
   


### PR DESCRIPTION
Found a workaround in our rst files to make internal links have _unix in them which prevents a bug in the processing of the files