### PR TITLE
Update oval 5 URL based namespace with mitre.org to URN based OVAL 6 namespaces

### DIFF
--- a/guidelines/oval-schema-documentation/unix-definitions-schema.rst
+++ b/guidelines/oval-schema-documentation/unix-definitions-schema.rst
@@ -10,18 +10,18 @@ The OVAL Schema is maintained by the OVAL Community. For more information, inclu
 
 Test Listing  
 ---------------------------------------------------------
-* :ref:`dnscache_test` (Deprecated)  
-* :ref:`file_test`  
-* :ref:`fileextendedattribute_test` (Deprecated)  
-* :ref:`gconf_test` (Deprecated)  
-* :ref:`inetd_test` (Deprecated)  
+* :ref:`dnscache_test_unix` 
+* :ref:`file_test_unix`  
+* :ref:`fileextendedattribute_test`  
+* :ref:`gconf_test` 
+* :ref:`inetd_test` 
 * :ref:`interface_test`  
 * :ref:`password_test`  
-* :ref:`process_test` (Deprecated)  
-* :ref:`process58_test`  
-* :ref:`routingtable_test` (Deprecated)  
+* :ref:`process_test_unix`   
+* :ref:`process58_test_unix`  
+* :ref:`routingtable_test` 
 * :ref:`runlevel_test`  
-* :ref:`sccs_test` (Deprecated)  
+* :ref:`sccs_test` 
 * :ref:`shadow_test`  
 * :ref:`sshd_test`  
 * :ref:`symlink_test`  
@@ -31,9 +31,9 @@ Test Listing
   
 ______________
   
-.. _dnscache_test:  
+.. _dnscache_test_unix:  
   
-< dnscache_test > (Deprecated)  
+< dnscache_test > (unix) (Deprecated)  
 ---------------------------------------------------------
 Deprecation Info  
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -111,9 +111,9 @@ Child Elements
   
 ______________
   
-.. _file_test:  
+.. _file_test_unix:  
   
-< file_test >  
+< file_test >  (unix)
 ---------------------------------------------------------
 The file test is used to check metadata associated with UNIX files, of the sort returned by either an ls command, stat command or stat() system call. It extends the standard TestType as defined in the oval-definitions-schema and one should refer to the TestType description for more information. The required object element references a file_object and the optional state element specifies the metadata to check.
 
@@ -598,7 +598,7 @@ ______________
   
 .. _interface_test:  
   
-< interface_test >  
+< interface_test >  (unix)
 ---------------------------------------------------------
 The interface test enumerates various attributes about the interfaces on a system. It extends the standard TestType as defined in the oval-definitions-schema and one should refer to the TestType description for more information. The required object element references an interface_object and the optional state element specifies the interface information to check.
 
@@ -779,9 +779,9 @@ Child Elements
   
 ______________
   
-.. _process_test:  
+.. _process_test_unix:  
   
-< process_test > (Deprecated)  
+< process_test > (unix) (Deprecated)  
 ---------------------------------------------------------
 Deprecation Info  
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -888,9 +888,9 @@ Child Elements
   
 ______________
   
-.. _process58_test:  
+.. _process58_test_unix:  
   
-< process58_test >  
+< process58_test >  (unix)
 ---------------------------------------------------------
 The process58_test is used to check information found in the UNIX processes. It is equivalent to parsing the output of the ps command. It extends the standard TestType as defined in the oval-definitions-schema and one should refer to the TestType description for more information. The required object element references a process58_object and the optional state element references a process58_state that specifies the process information to check.
 

--- a/guidelines/oval-schema-documentation/windows-definitions-schema.rst
+++ b/guidelines/oval-schema-documentation/windows-definitions-schema.rst
@@ -10,56 +10,56 @@ The OVAL Schema is maintained by the OVAL Community. For more information, inclu
 
 Test Listing  
 ---------------------------------------------------------
-* :ref:`accesstoken_test` (Deprecated)  
-* :ref:`activedirectory_test` (Deprecated)  
-* :ref:`activedirectory57_test` (Deprecated)  
-* :ref:`auditeventpolicy_test` (Deprecated)  
+* :ref:`accesstoken_test`  
+* :ref:`activedirectory_test` 
+* :ref:`activedirectory57_test`  
+* :ref:`auditeventpolicy_test` 
 * :ref:`auditeventpolicysubcategories_test`  
 * :ref:`cmdlet_test`  
-* :ref:`dnscache_test` (Deprecated)  
+* :ref:`dnscache_test`   
 * :ref:`file_test`  
-* :ref:`fileauditedpermissions53_test` (Deprecated)  
-* :ref:`fileauditedpermissions_test` (Deprecated)  
+* :ref:`fileauditedpermissions53_test`  
+* :ref:`fileauditedpermissions_test`  
 * :ref:`fileeffectiverights53_test`  
-* :ref:`fileeffectiverights_test` (Deprecated)  
-* :ref:`group_test` (Deprecated)  
+* :ref:`fileeffectiverights_test`   
+* :ref:`group_test`  
 * :ref:`group_sid_test`  
-* :ref:`interface_test` (Deprecated)  
-* :ref:`junction_test` (Deprecated)  
-* :ref:`license_test` (Deprecated)  
+* :ref:`interface_test`   
+* :ref:`junction_test`  
+* :ref:`license_test`   
 * :ref:`lockoutpolicy_test`  
-* :ref:`metabase_test` (Deprecated)  
+* :ref:`metabase_test` 
 * :ref:`ntuser_test`  
 * :ref:`passwordpolicy_test`  
-* :ref:`peheader_test` (Deprecated)  
-* :ref:`port_test` (Deprecated)  
-* :ref:`printereffectiverights_test` (Deprecated)  
-* :ref:`process_test` (Deprecated)  
-* :ref:`process58_test` (Deprecated)  
+* :ref:`peheader_test` 
+* :ref:`port_test` 
+* :ref:`printereffectiverights_test`
+* :ref:`process_test`  
+* :ref:`process58_test` 
 * :ref:`registry_test`  
-* :ref:`regkeyauditedpermissions53_test` (Deprecated)  
-* :ref:`regkeyauditedpermissions_test` (Deprecated)  
+* :ref:`regkeyauditedpermissions53_test`  
+* :ref:`regkeyauditedpermissions_test` 
 * :ref:`regkeyeffectiverights53_test`  
-* :ref:`regkeyeffectiverights_test` (Deprecated)  
+* :ref:`regkeyeffectiverights_test`   
 * :ref:`service_test`  
-* :ref:`serviceeffectiverights_test` (Deprecated)  
-* :ref:`sharedresource_test` (Deprecated)  
-* :ref:`sharedresourceauditedpermissions_test` (Deprecated)  
-* :ref:`sharedresourceeffectiverights_test` (Deprecated)  
+* :ref:`serviceeffectiverights_test` 
+* :ref:`sharedresource_test`  
+* :ref:`sharedresourceauditedpermissions_test`  
+* :ref:`sharedresourceeffectiverights_test`   
 * :ref:`sid_test`  
 * :ref:`sid_sid_test`  
-* :ref:`systemmetric_test` (Deprecated)  
-* :ref:`uac_test` (Deprecated)  
-* :ref:`user_test` (Deprecated)  
+* :ref:`systemmetric_test` 
+* :ref:`uac_test`  
+* :ref:`user_test` 
 * :ref:`user_sid55_test`  
-* :ref:`user_sid_test` (Deprecated)  
+* :ref:`user_sid_test`  
 * :ref:`userright_test`  
 * :ref:`appcmd_test`  
 * :ref:`appcmdlistconfig_test`  
-* :ref:`volume_test` (Deprecated)  
-* :ref:`wmi_test` (Deprecated)  
+* :ref:`volume_test` 
+* :ref:`wmi_test` 
 * :ref:`wmi57_test`  
-* :ref:`wuaupdatesearcher_test` (Deprecated)  
+* :ref:`wuaupdatesearcher_test` 
   
 ______________
   

--- a/oval-schemas/aix-definitions-schema.xsd
+++ b/oval-schemas/aix-definitions-schema.xsd
@@ -1,22 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-            xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5"
-            xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5"
-            xmlns:aix-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#aix"
+            xmlns:oval="urn:oval:v6:common"
+            xmlns:oval-def="urn:oval:v6:definitions"
+            xmlns:aix-def="urn:oval:v6:definitions:aix"
             xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-            targetNamespace="http://oval.mitre.org/XMLSchema/oval-definitions-5#aix"
-            elementFormDefault="qualified" version="5.12">
-      <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-definitions-5" schemaLocation="oval-definitions-schema.xsd"/>
+            targetNamespace="urn:oval:v6:definitions:aix"
+            elementFormDefault="qualified" version="6.0">
+      <xsd:import namespace="urn:oval:v6:definitions" schemaLocation="oval-definitions-schema.xsd"/>
       <xsd:annotation>
             <xsd:documentation>The following is a description of the elements, types, and attributes that compose the AIX specific tests found in Open Vulnerability and Assessment Language (OVAL). Each test is an extension of the standard test element defined in the Core Definition Schema. Through extension, each test inherits a set of elements and attributes that are shared amongst all OVAL tests. Each test is described in detail and should provide the information necessary to understand what each element and attribute represents. This document is intended for developers and assumes some familiarity with XML. A high level description of the interaction between the different tests and their relationship to the Core Definition Schema is not outlined here.</xsd:documentation>
             <xsd:documentation>This schema was originally developed by Yuzheng Zhou and Todd Dolinsky at Hewlett-Packard. The OVAL Schema is maintained by the OVAL Community. For more information, including how to get involved in the project and how to submit change requests, please visit the OVAL website at https://github.com/OVAL-Community/.</xsd:documentation>
             <xsd:appinfo>
                   <schema>AIX Definition</schema>
-                  <version>5.12</version>
-                  <date>11/29/2024 09:00:00 AM</date>
+                  <version>6.0</version>
+                  <date>1/1/2025 09:00:00 AM</date>
                   <terms_of_use>This software is an open standard developed by multiple parties, including the United States Government (Government). The Government hereby grants you a non-exclusive, royalty-free, worldwide license to use, modify, and/or reproduce the software for any lawful purpose provided that you reproduce this License/Disclaimer language with any use/modification/copy of the software. The Government assumes no responsibility whatsoever for this software's use by other parties, and the software is provided "AS IS" without warranty or guarantee of any kind, express or implied, including, but not limited to, the warranties of merchantability, fitness for a particular purpose, and noninfringement. In no event shall the Government be liable for any claim, damages or other liability, whether in an action of contract, tort or other dealings in the software. The Government has no obligation hereunder to provide maintenance, support, updates, enhancements, or modifications to the software. Users may submit proposals and/or updates regarding the software, which proposals and/or updates the Government, at its sole discretion, can choose to incorporate into the software. Proposals and/or updates submitted to the Government by users must be accompanied by a license to such proposals and/or updates that is no more restrictive than this License/Disclaimer.</terms_of_use>
-                  <sch:ns prefix="oval-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5"/>
-                  <sch:ns prefix="aix-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5#aix"/>
+                  <sch:ns prefix="oval-def" urn="urn:oval:v6:definitions"/>
+                  <sch:ns prefix="aix-def" urn="urn:oval:v6:definitions:aix"/>
                   <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
             </xsd:appinfo>
       </xsd:annotation>
@@ -31,7 +31,7 @@
                               <oval:test>interim_fix_test</oval:test>
                               <oval:object>interim_fix_object</oval:object>
                               <oval:state>interim_fix_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#aix">interim_fix_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:aix">interim_fix_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -75,7 +75,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#aix') and ($state_name='interim_fix_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:aix') and ($state_name='interim_fix_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -144,7 +144,7 @@
                               <oval:test>fileset_test</oval:test>
                               <oval:object>fileset_object</oval:object>
                               <oval:state>fileset_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#aix">fileset_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:aix">fileset_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -182,7 +182,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#aix') and ($state_name='fileset_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:aix') and ($state_name='fileset_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -251,7 +251,7 @@
                               <oval:test>fix_test</oval:test>
                               <oval:object>fix_object</oval:object>
                               <oval:state>fix_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#aix">fix_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:aix">fix_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -289,7 +289,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#aix') and ($state_name='fix_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:aix') and ($state_name='fix_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>

--- a/oval-schemas/aix-system-characteristics-schema.xsd
+++ b/oval-schemas/aix-system-characteristics-schema.xsd
@@ -1,16 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:oval-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5" xmlns:aix-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#aix" xmlns:sch="http://purl.oclc.org/dsdl/schematron" targetNamespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#aix" elementFormDefault="qualified" version="5.12">
-      <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5" schemaLocation="oval-system-characteristics-schema.xsd"/>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
+xmlns:oval-sc="urn:oval:v6:system-characteristics" 
+xmlns:aix-sc="urn:oval:v6:system-characteristics:aix" 
+xmlns:sch="http://purl.oclc.org/dsdl/schematron" 
+targetNamespace="urn:oval:v6:system-characteristics:aix" 
+elementFormDefault="qualified" version="6.0">
+      <xsd:import namespace="urn:oval:v6:system-characteristics" schemaLocation="oval-system-characteristics-schema.xsd"/>
       <xsd:annotation>
             <xsd:documentation>The following is a description of the elements, types, and attributes that compose the AIX specific system characteristic items found in Open Vulnerability and Assessment Language (OVAL). Each item is an extension of the standard test element defined in the Core Definition Schema. Through extension, each test inherits a set of elements and attributes that are shared amongst all OVAL tests. Each test is described in detail and should provide the information necessary to understand what each element and attribute represents. This document is intended for developers and assumes some familiarity with XML. A high level description of the interaction between the different tests and their relationship to the Core Definition Schema is not outlined here.</xsd:documentation>
             <xsd:documentation>This schema was originally developed by Yuzheng Zhou and Todd Dolinsky at Hewlett-Packard. The OVAL Schema is maintained by the OVAL Community. For more information, including how to get involved in the project and how to submit change requests, please visit the OVAL website at https://github.com/OVAL-Community/.</xsd:documentation>
             <xsd:appinfo>
                   <schema>AIX System Characteristics</schema>
-                  <version>5.12</version>
-                  <date>11/29/2024 09:00:00 AM</date>
+                  <version>6.0</version>
+                  <date>1/1/2025 09:00:00 AM</date>
                   <terms_of_use>This software is an open standard developed by multiple parties, including the United States Government (Government). The Government hereby grants you a non-exclusive, royalty-free, worldwide license to use, modify, and/or reproduce the software for any lawful purpose provided that you reproduce this License/Disclaimer language with any use/modification/copy of the software. The Government assumes no responsibility whatsoever for this software's use by other parties, and the software is provided "AS IS" without warranty or guarantee of any kind, express or implied, including, but not limited to, the warranties of merchantability, fitness for a particular purpose, and noninfringement. In no event shall the Government be liable for any claim, damages or other liability, whether in an action of contract, tort or other dealings in the software. The Government has no obligation hereunder to provide maintenance, support, updates, enhancements, or modifications to the software. Users may submit proposals and/or updates regarding the software, which proposals and/or updates the Government, at its sole discretion, can choose to incorporate into the software. Proposals and/or updates submitted to the Government by users must be accompanied by a license to such proposals and/or updates that is no more restrictive than this License/Disclaimer.</terms_of_use>
-                  <sch:ns prefix="oval-sc" uri="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5"/>
-                  <sch:ns prefix="aix-sc" uri="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#aix"/>
+                  <sch:ns prefix="oval-sc" urn="urn:oval:v6:system-characteristics"/>
+                  <sch:ns prefix="aix-sc" urn="urn:oval:v6:system-characteristics:aix"/>
                   <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
             </xsd:appinfo>
       </xsd:annotation>

--- a/oval-schemas/android-definitions-schema.xsd
+++ b/oval-schemas/android-definitions-schema.xsd
@@ -1,22 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-            xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5"
-            xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5"
-            xmlns:android-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#android"
+            xmlns:oval="urn:oval:v6:common"
+            xmlns:oval-def="urn:oval:v6:definitions"
+            xmlns:android-def="urn:oval:v6:definitions:android"
             xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-            targetNamespace="http://oval.mitre.org/XMLSchema/oval-definitions-5#android" elementFormDefault="qualified" version="5.12">
-  <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-definitions-5" schemaLocation="oval-definitions-schema.xsd"/>
-  <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-common-5" schemaLocation="oval-common-schema.xsd"/>
+            targetNamespace="urn:oval:v6:definitions:android" elementFormDefault="qualified" version="6.0">
+  <xsd:import namespace="urn:oval:v6:definitions" schemaLocation="oval-definitions-schema.xsd"/>
+  <xsd:import namespace="urn:oval:v6:common" schemaLocation="oval-common-schema.xsd"/>
   <xsd:annotation>
     <xsd:documentation>The following is a description of the elements, types, and attributes that compose the Android specific tests found in Open Vulnerability and Assessment Language (OVAL). Each test is an extension of the standard test element defined in the Core Definition Schema. Through extension, each test inherits a set of elements and attributes that are shared amongst all OVAL tests. Each test is described in detail and should provide the information necessary to understand what each element and attribute represents. This document is intended for developers and assumes some familiarity with XML. A high level description of the interaction between the different tests and their relationship to the Core Definition Schema is not outlined here.</xsd:documentation>
     <xsd:documentation>The OVAL Schema is maintained by the OVAL Community. For more information, including how to get involved in the project and how to submit change requests, please visit the OVAL website at https://github.com/OVAL-Community/.</xsd:documentation>
     <xsd:appinfo>
       <schema>Android Definition</schema>
-      <version>5.12</version>
-      <date>11/29/2024 09:00:00 AM</date>
+      <version>6.0</version>
+      <date>1/1/2025 09:00:00 AM</date>
       <terms_of_use>This software is an open standard developed by multiple parties, including the United States Government (Government). The Government hereby grants you a non-exclusive, royalty-free, worldwide license to use, modify, and/or reproduce the software for any lawful purpose provided that you reproduce this License/Disclaimer language with any use/modification/copy of the software. The Government assumes no responsibility whatsoever for this software's use by other parties, and the software is provided "AS IS" without warranty or guarantee of any kind, express or implied, including, but not limited to, the warranties of merchantability, fitness for a particular purpose, and noninfringement. In no event shall the Government be liable for any claim, damages or other liability, whether in an action of contract, tort or other dealings in the software. The Government has no obligation hereunder to provide maintenance, support, updates, enhancements, or modifications to the software. Users may submit proposals and/or updates regarding the software, which proposals and/or updates the Government, at its sole discretion, can choose to incorporate into the software. Proposals and/or updates submitted to the Government by users must be accompanied by a license to such proposals and/or updates that is no more restrictive than this License/Disclaimer.</terms_of_use>
-      <sch:ns prefix="oval-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5"/>
-      <sch:ns prefix="android-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5#android"/>
+      <sch:ns prefix="oval-def" urn="urn:oval:v6:definitions"/>
+      <sch:ns prefix="android-def" urn="urn:oval:v6:definitions:android"/>
       <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
     </xsd:appinfo>
   </xsd:annotation>
@@ -31,7 +31,7 @@
           <oval:test>appmanager_test</oval:test>
           <oval:object>appmanager_object</oval:object>
           <oval:state>appmanager_state</oval:state>
-          <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#android">appmanager_item</oval:item>
+          <oval:item target_namespace="urn:oval:v6:system-characteristics:android">appmanager_item</oval:item>
         </oval:element_mapping>
       </xsd:appinfo>
 		<xsd:appinfo>
@@ -74,7 +74,7 @@
             <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
             <sch:let name="state_name" value="local-name($reffed_state)"/>
             <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-            <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#android') and ($state_name='appmanager_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+            <sch:assert test="(($state_namespace='urn:oval:v6:definitions:android') and ($state_name='appmanager_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
           </sch:rule>
         </sch:pattern>
       </xsd:appinfo>
@@ -193,7 +193,7 @@
           <oval:test>bluetooth_test</oval:test>
           <oval:object>bluetooth_object</oval:object>
           <oval:state>bluetooth_state</oval:state>
-          <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#android">bluetooth_item</oval:item>
+          <oval:item target_namespace="urn:oval:v6:system-characteristics:android">bluetooth_item</oval:item>
         </oval:element_mapping>
       </xsd:appinfo>
 		<xsd:appinfo>
@@ -268,7 +268,7 @@
           <oval:test>camera_test</oval:test>
           <oval:object>camera_object</oval:object>
           <oval:state>camera_state</oval:state>
-          <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#android">camera_item</oval:item>
+          <oval:item target_namespace="urn:oval:v6:system-characteristics:android">camera_item</oval:item>
         </oval:element_mapping>
       </xsd:appinfo>
       <xsd:appinfo>
@@ -334,11 +334,11 @@
     <xsd:annotation>
       <xsd:documentation>The certificate_test is used to check the certificates installed on the device.</xsd:documentation>
       <xsd:appinfo>
-        <oval:element_mapping xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5">
+        <oval:element_mapping xmlns:oval="urn:oval:v6:common">
           <oval:test>certificate_test</oval:test>
           <oval:object>certificate_object</oval:object>
           <oval:state>certificate_state</oval:state>
-          <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#android">certificate_item</oval:item>
+          <oval:item target_namespace="urn:oval:v6:system-characteristics:android">certificate_item</oval:item>
         </oval:element_mapping>
       </xsd:appinfo>
 		<xsd:appinfo>
@@ -408,7 +408,7 @@
           <oval:test>devicesettings_test</oval:test>
           <oval:object>devicesettings_object</oval:object>
           <oval:state>devicesettings_state</oval:state>
-          <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#android">devicesettings_item</oval:item>
+          <oval:item target_namespace="urn:oval:v6:system-characteristics:android">devicesettings_item</oval:item>
         </oval:element_mapping>
       </xsd:appinfo>
 		<xsd:appinfo>
@@ -508,7 +508,7 @@
           <oval:test>encryption_test</oval:test>
           <oval:object>encryption_object</oval:object>
           <oval:state>encryption_state</oval:state>
-          <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#android">encryption_item</oval:item>
+          <oval:item target_namespace="urn:oval:v6:system-characteristics:android">encryption_item</oval:item>
         </oval:element_mapping>
       </xsd:appinfo>
 		<xsd:appinfo>
@@ -583,7 +583,7 @@
           <oval:test>locationservice_test</oval:test>
           <oval:object>locationservice_object</oval:object>
           <oval:state>locationservice_state</oval:state>
-          <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#android">locationservice_item</oval:item>
+          <oval:item target_namespace="urn:oval:v6:system-characteristics:android">locationservice_item</oval:item>
         </oval:element_mapping>
       </xsd:appinfo>
 		<xsd:appinfo>
@@ -658,7 +658,7 @@
           <oval:test>network_test</oval:test>
           <oval:object>network_object</oval:object>
           <oval:state>network_state</oval:state>
-          <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#android">network_item</oval:item>
+          <oval:item target_namespace="urn:oval:v6:system-characteristics:android">network_item</oval:item>
         </oval:element_mapping>
       </xsd:appinfo>
 		<xsd:appinfo>
@@ -733,7 +733,7 @@
           <oval:test>password_test</oval:test>
           <oval:object>password_object</oval:object>
           <oval:state>password_state</oval:state>
-          <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#android">password_item</oval:item>
+          <oval:item target_namespace="urn:oval:v6:system-characteristics:android">password_item</oval:item>
         </oval:element_mapping>
       </xsd:appinfo>
 		<xsd:appinfo>
@@ -878,7 +878,7 @@
           <oval:test>systemdetails_test</oval:test>
           <oval:object>systemdetails_object</oval:object>
           <oval:state>systemdetails_state</oval:state>
-          <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#android">systemdetails_item</oval:item>
+          <oval:item target_namespace="urn:oval:v6:system-characteristics:android">systemdetails_item</oval:item>
         </oval:element_mapping>
       </xsd:appinfo>
 		<xsd:appinfo>
@@ -1003,7 +1003,7 @@
           <oval:test>wifi_test</oval:test>
           <oval:object>wifi_object</oval:object>
           <oval:state>wifi_state</oval:state>
-          <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#android">wifi_item</oval:item>
+          <oval:item target_namespace="urn:oval:v6:system-characteristics:android">wifi_item</oval:item>
         </oval:element_mapping>
       </xsd:appinfo>
 		<xsd:appinfo>
@@ -1078,7 +1078,7 @@
           <oval:test>wifinetwork_test</oval:test>
           <oval:object>wifinetwork_object</oval:object>
           <oval:state>wifinetwork_state</oval:state>
-          <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#android">wifinetwork_item</oval:item>
+          <oval:item target_namespace="urn:oval:v6:system-characteristics:android">wifinetwork_item</oval:item>
         </oval:element_mapping>
       </xsd:appinfo>
 		<xsd:appinfo>
@@ -1121,7 +1121,7 @@
             <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
             <sch:let name="state_name" value="local-name($reffed_state)"/>
             <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-            <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#android') and ($state_name='wifinetwork_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+            <sch:assert test="(($state_namespace='urn:oval:v6:definitions:android') and ($state_name='wifinetwork_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
           </sch:rule>
         </sch:pattern>
       </xsd:appinfo>
@@ -1225,7 +1225,7 @@
           <oval:test>telephony_test</oval:test>
           <oval:object>telephony_object</oval:object>
           <oval:state>telephony_state</oval:state>
-          <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#android">telephony_item</oval:item>
+          <oval:item target_namespace="urn:oval:v6:system-characteristics:android">telephony_item</oval:item>
         </oval:element_mapping>
       </xsd:appinfo>
 		<xsd:appinfo>

--- a/oval-schemas/android-system-characteristics-schema.xsd
+++ b/oval-schemas/android-system-characteristics-schema.xsd
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-            xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5"
-            xmlns:oval-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5"
-            xmlns:android-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#android"
+            xmlns:oval="urn:oval:v6:common"
+            xmlns:oval-sc="urn:oval:v6:system-characteristics"
+            xmlns:android-sc="urn:oval:v6:system-characteristics:android"
             xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-            targetNamespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#android"
-            elementFormDefault="qualified" version="5.12">
-  <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5" schemaLocation="oval-system-characteristics-schema.xsd"/>
-  <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-common-5" schemaLocation="oval-common-schema.xsd"/>
+            targetNamespace="urn:oval:v6:system-characteristics:android"
+            elementFormDefault="qualified" version="6.0">
+  <xsd:import namespace="urn:oval:v6:system-characteristics" schemaLocation="oval-system-characteristics-schema.xsd"/>
+  <xsd:import namespace="urn:oval:v6:common" schemaLocation="oval-common-schema.xsd"/>
   <xsd:annotation>
     <xsd:documentation>The following is a description of the elements, types, and attributes that compose the Android specific system characteristic items found in Open Vulnerability and Assessment Language (OVAL). Each item is an extension of the standard item element defined in the Core System Characteristic Schema. Through extension, each item inherits a set of elements and attributes that are shared amongst all OVAL Items. Each item is described in detail and should provide the information necessary to understand what each element and attribute represents. This document is intended for developers and assumes some familiarity with XML. A high level description of the interaction between the different tests and their relationship to the Core System Characteristic Schema is not outlined here.</xsd:documentation>
     <xsd:documentation>The OVAL Schema is maintained by the OVAL Community. For more information, including how to get involved in the project and how to submit change requests, please visit the OVAL website at https://github.com/OVAL-Community/.</xsd:documentation>
     <xsd:appinfo>
       <schema>Android System Characteristics</schema>
-      <version>5.12</version>
-      <date>11/29/2024 09:00:00 AM</date>
+      <version>6.0</version>
+      <date>1/1/2025 09:00:00 AM</date>
       <terms_of_use>This software is an open standard developed by multiple parties, including the United States Government (Government). The Government hereby grants you a non-exclusive, royalty-free, worldwide license to use, modify, and/or reproduce the software for any lawful purpose provided that you reproduce this License/Disclaimer language with any use/modification/copy of the software. The Government assumes no responsibility whatsoever for this software's use by other parties, and the software is provided "AS IS" without warranty or guarantee of any kind, express or implied, including, but not limited to, the warranties of merchantability, fitness for a particular purpose, and noninfringement. In no event shall the Government be liable for any claim, damages or other liability, whether in an action of contract, tort or other dealings in the software. The Government has no obligation hereunder to provide maintenance, support, updates, enhancements, or modifications to the software. Users may submit proposals and/or updates regarding the software, which proposals and/or updates the Government, at its sole discretion, can choose to incorporate into the software. Proposals and/or updates submitted to the Government by users must be accompanied by a license to such proposals and/or updates that is no more restrictive than this License/Disclaimer.</terms_of_use>
-      <sch:ns prefix="oval-sc" uri="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5"/>
-      <sch:ns prefix="android-sc" uri="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#android"/>
+      <sch:ns prefix="oval-sc" urn="urn:oval:v6:system-characteristics"/>
+      <sch:ns prefix="android-sc" urn="urn:oval:v6:system-characteristics:android"/>
       <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
     </xsd:appinfo>
   </xsd:annotation>

--- a/oval-schemas/apache-definitions-schema.xsd
+++ b/oval-schemas/apache-definitions-schema.xsd
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-            xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5"
-            xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5"
-            xmlns:apache-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#apache"
+            xmlns:oval="urn:oval:v6:common"
+            xmlns:oval-def="urn:oval:v6:definitions"
+            xmlns:apache-def="urn:oval:v6:definitions:apache"
             xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-            targetNamespace="http://oval.mitre.org/XMLSchema/oval-definitions-5#apache"
-            elementFormDefault="qualified" version="5.12">
-      <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-common-5" schemaLocation="oval-common-schema.xsd"/>
-      <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-definitions-5" schemaLocation="oval-definitions-schema.xsd"/>
+            targetNamespace="urn:oval:v6:definitions:apache"
+            elementFormDefault="qualified" version="6.0">
+      <xsd:import namespace="urn:oval:v6:common" schemaLocation="oval-common-schema.xsd"/>
+      <xsd:import namespace="urn:oval:v6:definitions" schemaLocation="oval-definitions-schema.xsd"/>
       <xsd:annotation>
             <xsd:documentation>The following is a description of the elements, types, and attributes that compose the Apache specific tests found in Open Vulnerability and Assessment Language (OVAL). Each test is an extension of the standard test element defined in the Core Definition Schema. Through extension, each test inherits a set of elements and attributes that are shared amongst all OVAL tests. Each test is described in detail and should provide the information necessary to understand what each element and attribute represents. This document is intended for developers and assumes some familiarity with XML. A high level description of the interaction between the different tests and their relationship to the Core Definition Schema is not outlined here.</xsd:documentation>
             <xsd:documentation>The OVAL Schema is maintained by the OVAL Community. For more information, including how to get involved in the project and how to submit change requests, please visit the OVAL website at https://github.com/OVAL-Community/.</xsd:documentation>
             <xsd:appinfo>
                   <schema>Apache Definition</schema>
-                  <version>5.12</version>
-                  <date>11/29/2024 09:00:00 AM</date>
+                  <version>6.0</version>
+                  <date>1/1/2025 09:00:00 AM</date>
                   <terms_of_use>This software is an open standard developed by multiple parties, including the United States Government (Government). The Government hereby grants you a non-exclusive, royalty-free, worldwide license to use, modify, and/or reproduce the software for any lawful purpose provided that you reproduce this License/Disclaimer language with any use/modification/copy of the software. The Government assumes no responsibility whatsoever for this software's use by other parties, and the software is provided "AS IS" without warranty or guarantee of any kind, express or implied, including, but not limited to, the warranties of merchantability, fitness for a particular purpose, and noninfringement. In no event shall the Government be liable for any claim, damages or other liability, whether in an action of contract, tort or other dealings in the software. The Government has no obligation hereunder to provide maintenance, support, updates, enhancements, or modifications to the software. Users may submit proposals and/or updates regarding the software, which proposals and/or updates the Government, at its sole discretion, can choose to incorporate into the software. Proposals and/or updates submitted to the Government by users must be accompanied by a license to such proposals and/or updates that is no more restrictive than this License/Disclaimer.</terms_of_use>
-                  <sch:ns prefix="oval-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5"/>
-                  <sch:ns prefix="apache-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5#apache"/>
+                  <sch:ns prefix="oval-def" urn="urn:oval:v6:definitions"/>
+                  <sch:ns prefix="apache-def" urn="urn:oval:v6:definitions:apache"/>
                   <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
             </xsd:appinfo>
       </xsd:annotation>
@@ -32,7 +32,7 @@
                               <oval:test>httpd_test</oval:test>
                               <oval:object>httpd_object</oval:object>
                               <oval:state>httpd_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#apache">httpd_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:apache">httpd_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>

--- a/oval-schemas/apache-system-characteristics-schema.xsd
+++ b/oval-schemas/apache-system-characteristics-schema.xsd
@@ -1,22 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-            xmlns:oval-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5"
-            xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5"
-            xmlns:apache-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#apache"
+            xmlns:oval-sc="urn:oval:v6:system-characteristics"
+            xmlns:oval="urn:oval:v6:common"
+            xmlns:apache-sc="urn:oval:v6:system-characteristics:apache"
             xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-            targetNamespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#apache"
-            elementFormDefault="qualified" version="5.12">
-	<xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5" schemaLocation="oval-system-characteristics-schema.xsd"/>
+            targetNamespace="urn:oval:v6:system-characteristics:apache"
+            elementFormDefault="qualified" version="6.0">
+	<xsd:import namespace="urn:oval:v6:system-characteristics" schemaLocation="oval-system-characteristics-schema.xsd"/>
 	<xsd:annotation>
 		<xsd:documentation>The following is a description of the elements, types, and attributes that compose the Apache specific system characteristic items found in Open Vulnerability and Assessment Language (OVAL).  Each item is an extension of the standard item element defined in the Core System Characteristic Schema.  Through extension, each item inherits a set of elements and attributes that are shared amongst all OVAL Items.  Each item is described in detail and should provide the information necessary to understand what each element and attribute represents.  This document is intended for developers and assumes some familiarity with XML.  A high level description of the interaction between the different tests and their relationship to the Core System Characteristic Schema is not outlined here.</xsd:documentation>
 		<xsd:documentation>The OVAL Schema is maintained by the OVAL Community. For more information, including how to get involved in the project and how to submit change requests, please visit the OVAL website at https://github.com/OVAL-Community/.</xsd:documentation>
 		<xsd:appinfo>
 		     <schema>Apache System Characteristics</schema>
-		     <version>5.12</version>
-		     <date>11/29/2024 09:00:00 AM</date>
+		     <version>6.0</version>
+		     <date>1/1/2025 09:00:00 AM</date>
 		      <terms_of_use>This software is an open standard developed by multiple parties, including the United States Government (Government). The Government hereby grants you a non-exclusive, royalty-free, worldwide license to use, modify, and/or reproduce the software for any lawful purpose provided that you reproduce this License/Disclaimer language with any use/modification/copy of the software. The Government assumes no responsibility whatsoever for this software's use by other parties, and the software is provided "AS IS" without warranty or guarantee of any kind, express or implied, including, but not limited to, the warranties of merchantability, fitness for a particular purpose, and noninfringement. In no event shall the Government be liable for any claim, damages or other liability, whether in an action of contract, tort or other dealings in the software. The Government has no obligation hereunder to provide maintenance, support, updates, enhancements, or modifications to the software. Users may submit proposals and/or updates regarding the software, which proposals and/or updates the Government, at its sole discretion, can choose to incorporate into the software. Proposals and/or updates submitted to the Government by users must be accompanied by a license to such proposals and/or updates that is no more restrictive than this License/Disclaimer.</terms_of_use>
-			<sch:ns prefix="oval-sc" uri="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5"/>
-			<sch:ns prefix="apache-sc" uri="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#windows"/>
+			<sch:ns prefix="oval-sc" urn="urn:oval:v6:system-characteristics"/>
+			<sch:ns prefix="apache-sc" urn="urn:oval:v6:system-characteristics:windows"/>
 		    <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
 		</xsd:appinfo>
 	</xsd:annotation>

--- a/oval-schemas/apple-ios-definitions-schema.xsd
+++ b/oval-schemas/apple-ios-definitions-schema.xsd
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-            xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5"
-            xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5"
-            xmlns:apple-ios-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#apple_ios"
+            xmlns:oval="urn:oval:v6:common"
+            xmlns:oval-def="urn:oval:v6:definitions"
+            xmlns:apple-ios-def="urn:oval:v6:definitions:apple_ios"
             xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-            targetNamespace="http://oval.mitre.org/XMLSchema/oval-definitions-5#apple_ios"
-            elementFormDefault="qualified" version="5.12">
-  <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-common-5" schemaLocation="oval-common-schema.xsd"/>
-  <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-definitions-5" schemaLocation="oval-definitions-schema.xsd"/>
+            targetNamespace="urn:oval:v6:definitions:apple_ios"
+            elementFormDefault="qualified" version="6.0">
+  <xsd:import namespace="urn:oval:v6:common" schemaLocation="oval-common-schema.xsd"/>
+  <xsd:import namespace="urn:oval:v6:definitions" schemaLocation="oval-definitions-schema.xsd"/>
   <xsd:annotation>
     <xsd:documentation>The following is a description of the elements, types, and attributes that compose the Apple iOS specific tests found in Open Vulnerability and Assessment Language (OVAL). Each item is an extension of the standard item element defined in the Core Definition Schema. Through extension, each item inherits a set of elements and attributes that are shared amongst all OVAL Items. Each item is described in detail and should provide the information necessary to understand what each element and attribute represents. This document is intended for developers and assumes some familiarity with XML. A high level description of the interaction between the different tests and their relationship to the Core Definition Schema is not outlined here.</xsd:documentation>
     <xsd:documentation>The OVAL Schema is maintained by the OVAL Community. For more information, including how to get involved in the project and how to submit change requests, please visit the OVAL website at https://github.com/OVAL-Community/.</xsd:documentation>
     <xsd:documentation>See public documentation at https://developer.apple.com/library/ios/featuredarticles/iPhoneConfigurationProfileRef/Introduction/Introduction.html</xsd:documentation>
     <xsd:appinfo>
       <schema>Apple iOS Definition</schema>
-      <version>5.12</version>
-      <date>11/29/2024 09:00:00 AM</date>
+      <version>6.0</version>
+      <date>1/1/2025 09:00:00 AM</date>
       <terms_of_use>This software is an open standard developed by multiple parties, including the United States Government (Government). The Government hereby grants you a non-exclusive, royalty-free, worldwide license to use, modify, and/or reproduce the software for any lawful purpose provided that you reproduce this License/Disclaimer language with any use/modification/copy of the software. The Government assumes no responsibility whatsoever for this software's use by other parties, and the software is provided "AS IS" without warranty or guarantee of any kind, express or implied, including, but not limited to, the warranties of merchantability, fitness for a particular purpose, and noninfringement. In no event shall the Government be liable for any claim, damages or other liability, whether in an action of contract, tort or other dealings in the software. The Government has no obligation hereunder to provide maintenance, support, updates, enhancements, or modifications to the software. Users may submit proposals and/or updates regarding the software, which proposals and/or updates the Government, at its sole discretion, can choose to incorporate into the software. Proposals and/or updates submitted to the Government by users must be accompanied by a license to such proposals and/or updates that is no more restrictive than this License/Disclaimer.</terms_of_use>
-      <sch:ns prefix="oval-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5"/>
-      <sch:ns prefix="apple-ios-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5#apple_ios"/>
+      <sch:ns prefix="oval-def" urn="urn:oval:v6:definitions"/>
+      <sch:ns prefix="apple-ios-def" urn="urn:oval:v6:definitions:apple_ios"/>
       <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
     </xsd:appinfo>
   </xsd:annotation>
@@ -33,7 +33,7 @@
           <oval:test>globalrestrictions_test</oval:test>
           <oval:object>globalrestrictions_object</oval:object>
           <oval:state>globalrestrictions_state</oval:state>
-          <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#apple_ios">globalrestrictions_item</oval:item>
+          <oval:item target_namespace="urn:oval:v6:system-characteristics:apple_ios">globalrestrictions_item</oval:item>
         </oval:element_mapping>
       </xsd:appinfo>
 		<xsd:appinfo>
@@ -298,7 +298,7 @@
           <oval:test>passcodepolicy_test</oval:test>
           <oval:object>passcodepolicy_object</oval:object>
           <oval:state>passcodepolicy_state</oval:state>
-          <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#apple_ios">passcodepolicy_item</oval:item>
+          <oval:item target_namespace="urn:oval:v6:system-characteristics:apple_ios">passcodepolicy_item</oval:item>
         </oval:element_mapping>
       </xsd:appinfo>
 		<xsd:appinfo>
@@ -414,7 +414,7 @@
           <oval:test>profile_test</oval:test>
           <oval:object>profile_object</oval:object>
           <oval:state>profile_state</oval:state>
-          <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#apple_ios">profile_item</oval:item>
+          <oval:item target_namespace="urn:oval:v6:system-characteristics:apple_ios">profile_item</oval:item>
         </oval:element_mapping>
       </xsd:appinfo>
 		<xsd:appinfo>
@@ -457,7 +457,7 @@
             <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
             <sch:let name="state_name" value="local-name($reffed_state)"/>
             <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-            <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#apple-ios') and ($state_name='profile_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+            <sch:assert test="(($state_namespace='urn:oval:v6:definitions:apple-ios') and ($state_name='profile_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
           </sch:rule>
         </sch:pattern>
       </xsd:appinfo>

--- a/oval-schemas/apple-ios-system-characteristics-schema.xsd
+++ b/oval-schemas/apple-ios-system-characteristics-schema.xsd
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-            xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5"
-            xmlns:oval-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5"
-            xmlns:apple-ios-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#apple_ios"
+            xmlns:oval="urn:oval:v6:common"
+            xmlns:oval-sc="urn:oval:v6:system-characteristics"
+            xmlns:apple-ios-sc="urn:oval:v6:system-characteristics:apple_ios"
             xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-            targetNamespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#apple_ios"
-            elementFormDefault="qualified" version="5.12">
-  <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5" schemaLocation="oval-system-characteristics-schema.xsd"/>
-  <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-common-5" schemaLocation="oval-common-schema.xsd"/>
+            targetNamespace="urn:oval:v6:system-characteristics:apple_ios"
+            elementFormDefault="qualified" version="6.0">
+  <xsd:import namespace="urn:oval:v6:system-characteristics" schemaLocation="oval-system-characteristics-schema.xsd"/>
+  <xsd:import namespace="urn:oval:v6:common" schemaLocation="oval-common-schema.xsd"/>
   <xsd:annotation>
     <xsd:documentation>The following is a description of the elements, types, and attributes that compose the Apple iOS specific system characteristic items found in Open Vulnerability and Assessment Language (OVAL). Each item is an extension of the standard item element defined in the Core System Characteristic Schema. Through extension, each item inherits a set of elements and attributes that are shared amongst all OVAL Items. Each item is described in detail and should provide the information necessary to understand what each element and attribute represents. This document is intended for developers and assumes some familiarity with XML. A high level description of the interaction between the different tests and their relationship to the Core System Characteristic Schema is not outlined here.</xsd:documentation>
     <xsd:documentation>The OVAL Schema is maintained by the OVAL Community. For more information, including how to get involved in the project and how to submit change requests, please visit the OVAL website at https://github.com/OVAL-Community/.</xsd:documentation>
     <xsd:documentation>See public documentation at https://developer.apple.com/library/ios/featuredarticles/iPhoneConfigurationProfileRef/Introduction/Introduction.html</xsd:documentation>
     <xsd:appinfo>
       <schema>Apple iOS System Characteristics</schema>
-      <version>5.12</version>
-      <date>11/29/2024 09:00:00 AM</date>
+      <version>6.0</version>
+      <date>1/1/2025 09:00:00 AM</date>
       <terms_of_use>This software is an open standard developed by multiple parties, including the United States Government (Government). The Government hereby grants you a non-exclusive, royalty-free, worldwide license to use, modify, and/or reproduce the software for any lawful purpose provided that you reproduce this License/Disclaimer language with any use/modification/copy of the software. The Government assumes no responsibility whatsoever for this software's use by other parties, and the software is provided "AS IS" without warranty or guarantee of any kind, express or implied, including, but not limited to, the warranties of merchantability, fitness for a particular purpose, and noninfringement. In no event shall the Government be liable for any claim, damages or other liability, whether in an action of contract, tort or other dealings in the software. The Government has no obligation hereunder to provide maintenance, support, updates, enhancements, or modifications to the software. Users may submit proposals and/or updates regarding the software, which proposals and/or updates the Government, at its sole discretion, can choose to incorporate into the software. Proposals and/or updates submitted to the Government by users must be accompanied by a license to such proposals and/or updates that is no more restrictive than this License/Disclaimer.</terms_of_use>
-      <sch:ns prefix="oval-sc" uri="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5"/>
-      <sch:ns prefix="apple-ios-sc" uri="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#apple_ios"/>
+      <sch:ns prefix="oval-sc" urn="urn:oval:v6:system-characteristics"/>
+      <sch:ns prefix="apple-ios-sc" urn="urn:oval:v6:system-characteristics:apple_ios"/>
       <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
     </xsd:appinfo>
   </xsd:annotation>

--- a/oval-schemas/asa-definitions-schema.xsd
+++ b/oval-schemas/asa-definitions-schema.xsd
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-            xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5"
-            xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5"
-            xmlns:asa-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#asa"
+            xmlns:oval="urn:oval:v6:common"
+            xmlns:oval-def="urn:oval:v6:definitions"
+            xmlns:asa-def="urn:oval:v6:definitions:asa"
             xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-            targetNamespace="http://oval.mitre.org/XMLSchema/oval-definitions-5#asa"
-            elementFormDefault="qualified" version="5.12">
-      <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-definitions-5" schemaLocation="oval-definitions-schema.xsd" />
+            targetNamespace="urn:oval:v6:definitions:asa"
+            elementFormDefault="qualified" version="6.0">
+      <xsd:import namespace="urn:oval:v6:definitions" schemaLocation="oval-definitions-schema.xsd" />
       <xsd:annotation>
             <xsd:documentation>The following is a description of the elements, types, and attributes that compose the Cisco ASA specific tests found in Open Vulnerability and Assessment Language (OVAL). Each test is an extension of the standard test element defined in the Core Definition Schema. Through extension, each test inherits a set of elements and attributes that are shared amongst all OVAL tests. Each test is described in detail and should provide the information necessary to understand what each element and attribute represents. This document is intended for developers and assumes some familiarity with XML. A high level description of the interaction between the different tests and their relationship to the Core Definition Schema is not outlined here.</xsd:documentation>
             <xsd:documentation>The OVAL Schema is maintained by the OVAL Community. For more information, including how to get involved in the project and how to submit change requests, please visit the OVAL website at https://github.com/OVAL-Community/.</xsd:documentation>
             <xsd:documentation>Thanks to Omar Santos and Panos Kampanakis of Cisco for providing these tests.</xsd:documentation>
             <xsd:appinfo>
                   <schema>Cisco ASA Definition</schema>
-                  <version>5.12</version>
-                  <date>11/29/2024 09:00:00 AM</date>
+                  <version>6.0</version>
+                  <date>1/1/2025 09:00:00 AM</date>
                   <terms_of_use>This software is an open standard developed by multiple parties, including the United States Government (Government). The Government hereby grants you a non-exclusive, royalty-free, worldwide license to use, modify, and/or reproduce the software for any lawful purpose provided that you reproduce this License/Disclaimer language with any use/modification/copy of the software. The Government assumes no responsibility whatsoever for this software's use by other parties, and the software is provided "AS IS" without warranty or guarantee of any kind, express or implied, including, but not limited to, the warranties of merchantability, fitness for a particular purpose, and noninfringement. In no event shall the Government be liable for any claim, damages or other liability, whether in an action of contract, tort or other dealings in the software. The Government has no obligation hereunder to provide maintenance, support, updates, enhancements, or modifications to the software. Users may submit proposals and/or updates regarding the software, which proposals and/or updates the Government, at its sole discretion, can choose to incorporate into the software. Proposals and/or updates submitted to the Government by users must be accompanied by a license to such proposals and/or updates that is no more restrictive than this License/Disclaimer.</terms_of_use>
-                  <sch:ns prefix="oval-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5" />
-                  <sch:ns prefix="asa-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5#asa" />
+                  <sch:ns prefix="oval-def" urn="urn:oval:v6:definitions" />
+                  <sch:ns prefix="asa-def" urn="urn:oval:v6:definitions:asa" />
                   <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance" />
             </xsd:appinfo>
       </xsd:annotation>
@@ -32,7 +32,7 @@
                               <oval:test>acl_test</oval:test>
                               <oval:object>acl_object</oval:object>
                               <oval:state>acl_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#asa">acl_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:asa">acl_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -79,7 +79,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]" />
                                     <sch:let name="state_name" value="local-name($reffed_state)" />
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)" />
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#asa') and ($state_name='acl_state'))">State referenced in filter for <sch:value-of select="name($parent_object)" /> '<sch:value-of select="$parent_object_id" />' is of the wrong type.</sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:asa') and ($state_name='acl_state'))">State referenced in filter for <sch:value-of select="name($parent_object)" /> '<sch:value-of select="$parent_object_id" />' is of the wrong type.</sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -168,7 +168,7 @@
                               <oval:test>class_map_test</oval:test>
                               <oval:object>class_map_object</oval:object>
                               <oval:state>class_map_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#asa">class_map_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:asa">class_map_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -213,7 +213,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#asa') and ($state_name='class_map_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type.</sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:asa') and ($state_name='class_map_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type.</sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -302,7 +302,7 @@
                               <oval:test>interface_test</oval:test>
                               <oval:object>interface_object</oval:object>
                               <oval:state>interface_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#asa">interface_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:asa">interface_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -347,7 +347,7 @@
                             <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                             <sch:let name="state_name" value="local-name($reffed_state)"/>
                             <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                            <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#asa') and ($state_name='interface_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type.</sch:assert>
+                            <sch:assert test="(($state_namespace='urn:oval:v6:definitions:asa') and ($state_name='interface_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type.</sch:assert>
                         </sch:rule>
                     </sch:pattern>
                 </xsd:appinfo>
@@ -472,7 +472,7 @@
                               <oval:test>line_test</oval:test>
                               <oval:object>line_object</oval:object>
                               <oval:state>line_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#asa">line_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:asa">line_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -510,7 +510,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#asa') and ($state_name='line_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:asa') and ($state_name='line_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -569,7 +569,7 @@
                               <oval:test>policy_map_test</oval:test>
                               <oval:object>policy_map_object</oval:object>
                               <oval:state>policy_map_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#asa">policy_map_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:asa">policy_map_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -614,7 +614,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#asa') and ($state_name='policy_map_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type.</sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:asa') and ($state_name='policy_map_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type.</sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -688,7 +688,7 @@
                               <oval:test>service_policy_test</oval:test>
                               <oval:object>service_policy_object</oval:object>
                               <oval:state>service_policy_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#asa">service_policy_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:asa">service_policy_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -733,7 +733,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#asa') and ($state_name='service_policy_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type.</sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:asa') and ($state_name='service_policy_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type.</sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -797,7 +797,7 @@
                               <oval:test>snmp_host_test</oval:test>
                               <oval:object>snmp_host_object</oval:object>
                               <oval:state>snmp_host_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#asa">snmp_host_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:asa">snmp_host_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -842,7 +842,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#asa') and ($state_name='snmp_host_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type.</sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:asa') and ($state_name='snmp_host_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type.</sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -926,7 +926,7 @@
                               <oval:test>snmp_user_test</oval:test>
                               <oval:object>snmp_user_object</oval:object>
                               <oval:state>snmp_user_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#asa">snmp_user_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:asa">snmp_user_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -971,7 +971,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#asa') and ($state_name='snmp_user_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type.</sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:asa') and ($state_name='snmp_user_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type.</sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -1040,7 +1040,7 @@
                               <oval:test>snmp_group_test</oval:test>
                               <oval:object>snmp_group_object</oval:object>
                               <oval:state>snmp_group_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#asa">snmp_group_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:asa">snmp_group_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -1085,7 +1085,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#asa') and ($state_name='snmp_group_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type.</sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:asa') and ($state_name='snmp_group_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type.</sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -1144,7 +1144,7 @@
                               <oval:test>tcp_map_test</oval:test>
                               <oval:object>tcp_map_object</oval:object>
                               <oval:state>tcp_map_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#asa">tcp_map_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:asa">tcp_map_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -1188,7 +1188,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#asa') and ($state_name='service_policy_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type.</sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:asa') and ($state_name='service_policy_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type.</sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -1247,7 +1247,7 @@
                               <oval:test>version_test</oval:test>
                               <oval:object>version_object</oval:object>
                               <oval:state>version_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#asa">version_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:asa">version_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>

--- a/oval-schemas/asa-system-characteristics-schema.xsd
+++ b/oval-schemas/asa-system-characteristics-schema.xsd
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-            xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5"
-            xmlns:oval-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5"
-            xmlns:asa-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#asa"
+            xmlns:oval="urn:oval:v6:common"
+            xmlns:oval-sc="urn:oval:v6:system-characteristics"
+            xmlns:asa-sc="urn:oval:v6:system-characteristics:asa"
             xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-            targetNamespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#asa"
-            elementFormDefault="qualified" version="5.12">
-      <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5" schemaLocation="oval-system-characteristics-schema.xsd" />
+            targetNamespace="urn:oval:v6:system-characteristics:asa"
+            elementFormDefault="qualified" version="6.0">
+      <xsd:import namespace="urn:oval:v6:system-characteristics" schemaLocation="oval-system-characteristics-schema.xsd" />
       <xsd:annotation>
             <xsd:documentation>The following is a description of the elements, types, and attributes that compose the Cisco ASA specific system characteristic items found in Open Vulnerability and Assessment Language (OVAL). Each item is an extension of the standard item element defined in the Core System Characteristic Schema. Through extension, each item inherits a set of elements and attributes that are shared amongst all OVAL Items. Each item is described in detail and should provide the information necessary to understand what each element and attribute represents. This document is intended for developers and assumes some familiarity with XML. A high level description of the interaction between the different tests and their relationship to the Core System Characteristic Schema is not outlined here.</xsd:documentation>
             <xsd:documentation>The OVAL Schema is maintained by the OVAL Community. For more information, including how to get involved in the project and how to submit change requests, please visit the OVAL website at https://github.com/OVAL-Community/.</xsd:documentation>
             <xsd:documentation>Thanks to Omar Santos and Panos Kampanakis of Cisco for providing these tests.</xsd:documentation>
             <xsd:appinfo>
                   <schema>Cisco ASA System Characteristics</schema>
-                  <version>5.12</version>
-                  <date>11/29/2024 09:00:00 AM</date>
+                  <version>6.0</version>
+                  <date>1/1/2025 09:00:00 AM</date>
                   <terms_of_use>This software is an open standard developed by multiple parties, including the United States Government (Government). The Government hereby grants you a non-exclusive, royalty-free, worldwide license to use, modify, and/or reproduce the software for any lawful purpose provided that you reproduce this License/Disclaimer language with any use/modification/copy of the software. The Government assumes no responsibility whatsoever for this software's use by other parties, and the software is provided "AS IS" without warranty or guarantee of any kind, express or implied, including, but not limited to, the warranties of merchantability, fitness for a particular purpose, and noninfringement. In no event shall the Government be liable for any claim, damages or other liability, whether in an action of contract, tort or other dealings in the software. The Government has no obligation hereunder to provide maintenance, support, updates, enhancements, or modifications to the software. Users may submit proposals and/or updates regarding the software, which proposals and/or updates the Government, at its sole discretion, can choose to incorporate into the software. Proposals and/or updates submitted to the Government by users must be accompanied by a license to such proposals and/or updates that is no more restrictive than this License/Disclaimer.</terms_of_use>
-                  <sch:ns prefix="oval-sc" uri="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5"/>
-                  <sch:ns prefix="asa-sc" uri="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#asa"/>
+                  <sch:ns prefix="oval-sc" urn="urn:oval:v6:system-characteristics"/>
+                  <sch:ns prefix="asa-sc" urn="urn:oval:v6:system-characteristics:asa"/>
                   <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance" />
             </xsd:appinfo>
       </xsd:annotation>

--- a/oval-schemas/aws-definitions-schema.xsd
+++ b/oval-schemas/aws-definitions-schema.xsd
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5" xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:aws-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#aws" xmlns:sch="http://purl.oclc.org/dsdl/schematron" targetNamespace="http://oval.mitre.org/XMLSchema/oval-definitions-5#aws" elementFormDefault="qualified" version="5.12">
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:oval="urn:oval:v6:common" xmlns:oval-def="urn:oval:v6:definitions" xmlns:aws-def="urn:oval:v6:definitions:aws" xmlns:sch="http://purl.oclc.org/dsdl/schematron" targetNamespace="urn:oval:v6:definitions:aws" elementFormDefault="qualified" version="6.0">
     
-    <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-common-5" schemaLocation="oval-common-schema.xsd"/>
-    <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-definitions-5" schemaLocation="oval-definitions-schema.xsd"/>
+    <xsd:import namespace="urn:oval:v6:common" schemaLocation="oval-common-schema.xsd"/>
+    <xsd:import namespace="urn:oval:v6:definitions" schemaLocation="oval-definitions-schema.xsd"/>
     
     <xsd:annotation>
         <xsd:documentation>
@@ -23,8 +23,8 @@
         </xsd:documentation>
         <xsd:appinfo>
             <schema>Amazon Web Services Definition</schema>
-            <version>5.12</version>
-            <date>11/29/2024 09:00:00 AM</date>
+            <version>6.0</version>
+            <date>1/1/2025 09:00:00 AM</date>
             <terms_of_use>
                 For the portion subject to the copyright in the United States: Copyright (c) 2016 United States 
                 Government. All Rights Reserved. Copyright (c) 2016, Center for Internet Security. All rights 
@@ -34,8 +34,8 @@
                 this license header must be included.
             </terms_of_use>
             
-            <sch:ns prefix="oval-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5"/>
-            <sch:ns prefix="aws-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5#aws"/>
+            <sch:ns prefix="oval-def" urn="urn:oval:v6:definitions"/>
+            <sch:ns prefix="aws-def" urn="urn:oval:v6:definitions:aws"/>
             <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
         </xsd:appinfo>
     </xsd:annotation>
@@ -58,7 +58,7 @@
                     <oval:test>api_test</oval:test>
                     <oval:object>api_object</oval:object>
                     <oval:state>api_state</oval:state>
-                    <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#aws">api_item</oval:item>
+                    <oval:item target_namespace="urn:oval:v6:system-characteristics:aws">api_item</oval:item>
                 </oval:element_mapping>
             </xsd:appinfo>
             <xsd:appinfo>
@@ -107,7 +107,7 @@
                         <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                         <sch:let name="state_name" value="local-name($reffed_state)"/>
                         <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                        <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#aws') and ($state_name='api_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                        <sch:assert test="(($state_namespace='urn:oval:v6:definitions:aws') and ($state_name='api_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                     </sch:rule>
                 </sch:pattern>
             </xsd:appinfo>
@@ -302,7 +302,7 @@
                     <oval:test>apicontent_test</oval:test>
                     <oval:object>apicontent_object</oval:object>
                     <oval:state>apicontent_state</oval:state>
-                    <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#aws">apicontent_item</oval:item>
+                    <oval:item target_namespace="urn:oval:v6:system-characteristics:aws">apicontent_item</oval:item>
                 </oval:element_mapping>
             </xsd:appinfo>
             <xsd:appinfo>
@@ -350,7 +350,7 @@
                         <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                         <sch:let name="state_name" value="local-name($reffed_state)"/>
                         <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                        <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#aws') and ($state_name='apicontent_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                        <sch:assert test="(($state_namespace='urn:oval:v6:definitions:aws') and ($state_name='apicontent_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                     </sch:rule>
                 </sch:pattern>
             </xsd:appinfo>
@@ -561,7 +561,7 @@
                     <oval:test>credentialreportuser_test</oval:test>
                     <oval:object>credentialreportuser_object</oval:object>
                     <oval:state>credentialreportuser_state</oval:state>
-                    <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#aws">credentialreportuser_item</oval:item>
+                    <oval:item target_namespace="urn:oval:v6:system-characteristics:aws">credentialreportuser_item</oval:item>
                 </oval:element_mapping>
             </xsd:appinfo>
             <xsd:appinfo>
@@ -749,7 +749,7 @@
                     <oval:test>credentialreportkey_test</oval:test>
                     <oval:object>credentialreportkey_object</oval:object>
                     <oval:state>credentialreportkey_state</oval:state>
-                    <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#aws">credentialreportkey_item</oval:item>
+                    <oval:item target_namespace="urn:oval:v6:system-characteristics:aws">credentialreportkey_item</oval:item>
                 </oval:element_mapping>
             </xsd:appinfo>
             <xsd:appinfo>
@@ -927,7 +927,7 @@
                     <oval:test>credentialreportcert_test</oval:test>
                     <oval:object>credentialreportcert_object</oval:object>
                     <oval:state>credentialreportcert_state</oval:state>
-                    <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#aws">credentialreportcert_item</oval:item>
+                    <oval:item target_namespace="urn:oval:v6:system-characteristics:aws">credentialreportcert_item</oval:item>
                 </oval:element_mapping>
             </xsd:appinfo>
             <xsd:appinfo>

--- a/oval-schemas/aws-system-characteristics-schema.xsd
+++ b/oval-schemas/aws-system-characteristics-schema.xsd
@@ -1,5 +1,5 @@
-<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:oval-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5" xmlns:aws-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#aws" xmlns:sch="http://purl.oclc.org/dsdl/schematron" targetNamespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#aws" elementFormDefault="qualified" version="5.12">
-    <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5" schemaLocation="oval-system-characteristics-schema.xsd"/>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:oval-sc="urn:oval:v6:system-characteristics" xmlns:oval="urn:oval:v6:common" xmlns:aws-sc="urn:oval:v6:system-characteristics:aws" xmlns:sch="http://purl.oclc.org/dsdl/schematron" targetNamespace="urn:oval:v6:system-characteristics:aws" elementFormDefault="qualified" version="6.0">
+    <xsd:import namespace="urn:oval:v6:system-characteristics" schemaLocation="oval-system-characteristics-schema.xsd"/>
     
     <xsd:annotation>
         <xsd:documentation>
@@ -17,8 +17,8 @@
         </xsd:documentation>
         <xsd:appinfo>
             <schema>Amazon Web Services System Characteristics</schema>
-            <version>5.12</version>
-            <date>11/29/2024 09:00:00 AM</date>
+            <version>6.0</version>
+            <date>1/1/2025 09:00:00 AM</date>
             <terms_of_use>
                 For the portion subject to the copyright in the United States: Copyright (c) 2016 United States Government. All Rights 
                 Reserved. Copyright (c) 2016, Center for Internet Security. All rights reserved. The contents of this file are subject 
@@ -26,8 +26,8 @@
                 language governing permissions and limitations for use of this schema. When distributing copies of the OVAL Schema, 
                 this license header must be included. 
             </terms_of_use>
-            <sch:ns prefix="oval-sc" uri="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5"/>
-            <sch:ns prefix="aws-sc" uri="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#aws"/>
+            <sch:ns prefix="oval-sc" urn="urn:oval:v6:system-characteristics"/>
+            <sch:ns prefix="aws-sc" urn="urn:oval:v6:system-characteristics:aws"/>
             <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
         </xsd:appinfo>
     </xsd:annotation>

--- a/oval-schemas/catos-definitions-schema.xsd
+++ b/oval-schemas/catos-definitions-schema.xsd
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-            xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5"
-            xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5"
-            xmlns:catos-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#catos"
+            xmlns:oval="urn:oval:v6:common"
+            xmlns:oval-def="urn:oval:v6:definitions"
+            xmlns:catos-def="urn:oval:v6:definitions:catos"
             xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-            targetNamespace="http://oval.mitre.org/XMLSchema/oval-definitions-5#catos"
-            elementFormDefault="qualified" version="5.12">
-      <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-common-5" schemaLocation="oval-common-schema.xsd"/>
-      <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-definitions-5" schemaLocation="oval-definitions-schema.xsd"/>
+            targetNamespace="urn:oval:v6:definitions:catos"
+            elementFormDefault="qualified" version="6.0">
+      <xsd:import namespace="urn:oval:v6:common" schemaLocation="oval-common-schema.xsd"/>
+      <xsd:import namespace="urn:oval:v6:definitions" schemaLocation="oval-definitions-schema.xsd"/>
       <xsd:annotation>
             <xsd:documentation>The following is a description of the elements, types, and attributes that compose the Cisco CatOS specific tests found in Open Vulnerability and Assessment Language (OVAL). Each test is an extension of the standard test element defined in the Core Definition Schema. Through extension, each test inherits a set of elements and attributes that are shared amongst all OVAL tests. Each test is described in detail and should provide the information necessary to understand what each element and attribute represents. This document is intended for developers and assumes some familiarity with XML. A high level description of the interaction between the different tests and their relationship to the Core Definition Schema is not outlined here</xsd:documentation>
           <xsd:documentation>This schema was originally developed by Yuzheng Zhou and Eric Grey at Hewlett-Packard. The OVAL Schema is maintained by the OVAL Community. For more information, including how to get involved in the project and how to submit change requests, please visit the OVAL website at https://github.com/OVAL-Community/.</xsd:documentation>
             <xsd:appinfo>
                   <schema>CatOS Definition</schema>
-                  <version>5.12</version>
-                  <date>11/29/2024 09:00:00 AM</date>
+                  <version>6.0</version>
+                  <date>1/1/2025 09:00:00 AM</date>
                   <terms_of_use>This software is an open standard developed by multiple parties, including the United States Government (Government). The Government hereby grants you a non-exclusive, royalty-free, worldwide license to use, modify, and/or reproduce the software for any lawful purpose provided that you reproduce this License/Disclaimer language with any use/modification/copy of the software. The Government assumes no responsibility whatsoever for this software's use by other parties, and the software is provided "AS IS" without warranty or guarantee of any kind, express or implied, including, but not limited to, the warranties of merchantability, fitness for a particular purpose, and noninfringement. In no event shall the Government be liable for any claim, damages or other liability, whether in an action of contract, tort or other dealings in the software. The Government has no obligation hereunder to provide maintenance, support, updates, enhancements, or modifications to the software. Users may submit proposals and/or updates regarding the software, which proposals and/or updates the Government, at its sole discretion, can choose to incorporate into the software. Proposals and/or updates submitted to the Government by users must be accompanied by a license to such proposals and/or updates that is no more restrictive than this License/Disclaimer.</terms_of_use>
-                  <sch:ns prefix="oval-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5"/>
-                  <sch:ns prefix="catos-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5#catos"/>
+                  <sch:ns prefix="oval-def" urn="urn:oval:v6:definitions"/>
+                  <sch:ns prefix="catos-def" urn="urn:oval:v6:definitions:catos"/>
                   <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
             </xsd:appinfo>
       </xsd:annotation>
@@ -32,7 +32,7 @@
                           <oval:test>line_test</oval:test>
                           <oval:object>line_object</oval:object>
                           <oval:state>line_state</oval:state>
-                          <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#catos">line_item</oval:item>
+                          <oval:item target_namespace="urn:oval:v6:system-characteristics:catos">line_item</oval:item>
                     </oval:element_mapping>
               </xsd:appinfo>
 				<xsd:appinfo>
@@ -76,7 +76,7 @@
                                 <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                 <sch:let name="state_name" value="local-name($reffed_state)"/>
                                 <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#catos') and ($state_name='line_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                <sch:assert test="(($state_namespace='urn:oval:v6:definitions:catos') and ($state_name='line_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                           </sch:rule>
                     </sch:pattern>
               </xsd:appinfo>
@@ -136,7 +136,7 @@
                             <oval:test>module_test</oval:test>
                             <oval:object>module_object</oval:object>
                             <oval:state>module_state</oval:state>
-                            <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#catos">module_item</oval:item>
+                            <oval:item target_namespace="urn:oval:v6:system-characteristics:catos">module_item</oval:item>
                       </oval:element_mapping>
                 </xsd:appinfo>
 				<xsd:appinfo>
@@ -180,7 +180,7 @@
                                 <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                 <sch:let name="state_name" value="local-name($reffed_state)"/>
                                 <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#catos') and ($state_name='module_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                <sch:assert test="(($state_namespace='urn:oval:v6:definitions:catos') and ($state_name='module_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                           </sch:rule>
                     </sch:pattern>
               </xsd:appinfo>
@@ -280,7 +280,7 @@
                           <oval:test>version55_test</oval:test>
                           <oval:object>version55_object</oval:object>
                           <oval:state>version55_state</oval:state>
-                          <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#catos">version_item</oval:item>
+                          <oval:item target_namespace="urn:oval:v6:system-characteristics:catos">version_item</oval:item>
                     </oval:element_mapping>
               </xsd:appinfo>
 				<xsd:appinfo>
@@ -361,7 +361,7 @@
                             <oval:test>version_test</oval:test>
                             <oval:object>version_object</oval:object>
                             <oval:state>version_state</oval:state>
-                            <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#catos">version_item</oval:item>
+                            <oval:item target_namespace="urn:oval:v6:system-characteristics:catos">version_item</oval:item>
                       </oval:element_mapping>
                 </xsd:appinfo>
 				<xsd:appinfo>

--- a/oval-schemas/catos-system-characteristics-schema.xsd
+++ b/oval-schemas/catos-system-characteristics-schema.xsd
@@ -1,22 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-            xmlns:oval-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5"
-            xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5"
-            xmlns:catos-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#catos"
+            xmlns:oval-sc="urn:oval:v6:system-characteristics"
+            xmlns:oval="urn:oval:v6:common"
+            xmlns:catos-sc="urn:oval:v6:system-characteristics:catos"
             xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-            targetNamespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#catos"
-            elementFormDefault="qualified" version="5.12">
-     <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5" schemaLocation="oval-system-characteristics-schema.xsd"/>
+            targetNamespace="urn:oval:v6:system-characteristics:catos"
+            elementFormDefault="qualified" version="6.0">
+     <xsd:import namespace="urn:oval:v6:system-characteristics" schemaLocation="oval-system-characteristics-schema.xsd"/>
      <xsd:annotation>
           <xsd:documentation>The following is a description of the elements, types, and attributes that compose the Cisco CatOS specific system characteristic items found in Open Vulnerability and Assessment Language (OVAL). Each item is an extension of the standard test element defined in the Core Definition Schema. Through extension, each test inherits a set of elements and attributes that are shared amongst all OVAL tests. Each test is described in detail and should provide the information necessary to understand what each element and attribute represents. This document is intended for developers and assumes some familiarity with XML. A high level description of the interaction between the different tests and their relationship to the Core Definition Schema is not outlined here.</xsd:documentation>
           <xsd:documentation>This schema was originally developed by Yuzheng Zhou at Hewlett-Packard. The OVAL Schema is maintained by the OVAL Community. For more information, including how to get involved in the project and how to submit change requests, please visit the OVAL website at https://github.com/OVAL-Community/.</xsd:documentation>
           <xsd:appinfo>
                <schema>CatOS System Characteristics</schema>
-               <version>5.12</version>
-               <date>11/29/2024 09:00:00 AM</date>
+               <version>6.0</version>
+               <date>1/1/2025 09:00:00 AM</date>
                 <terms_of_use>This software is an open standard developed by multiple parties, including the United States Government (Government). The Government hereby grants you a non-exclusive, royalty-free, worldwide license to use, modify, and/or reproduce the software for any lawful purpose provided that you reproduce this License/Disclaimer language with any use/modification/copy of the software. The Government assumes no responsibility whatsoever for this software's use by other parties, and the software is provided "AS IS" without warranty or guarantee of any kind, express or implied, including, but not limited to, the warranties of merchantability, fitness for a particular purpose, and noninfringement. In no event shall the Government be liable for any claim, damages or other liability, whether in an action of contract, tort or other dealings in the software. The Government has no obligation hereunder to provide maintenance, support, updates, enhancements, or modifications to the software. Users may submit proposals and/or updates regarding the software, which proposals and/or updates the Government, at its sole discretion, can choose to incorporate into the software. Proposals and/or updates submitted to the Government by users must be accompanied by a license to such proposals and/or updates that is no more restrictive than this License/Disclaimer.</terms_of_use>
-               <sch:ns prefix="oval-sc" uri="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5"/>
-               <sch:ns prefix="catos-sc" uri="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#catos"/>
+               <sch:ns prefix="oval-sc" urn="urn:oval:v6:system-characteristics"/>
+               <sch:ns prefix="catos-sc" urn="urn:oval:v6:system-characteristics:catos"/>
               <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
           </xsd:appinfo>
      </xsd:annotation>

--- a/oval-schemas/esx-definitions-schema.xsd
+++ b/oval-schemas/esx-definitions-schema.xsd
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-            xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5"
-            xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5"
-            xmlns:esx-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#esx"
+            xmlns:oval="urn:oval:v6:common"
+            xmlns:oval-def="urn:oval:v6:definitions"
+            xmlns:esx-def="urn:oval:v6:definitions:esx"
             xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-            targetNamespace="http://oval.mitre.org/XMLSchema/oval-definitions-5#esx"
-            elementFormDefault="qualified" version="5.12">
-      <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-common-5" schemaLocation="oval-common-schema.xsd"/>
-      <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-definitions-5" schemaLocation="oval-definitions-schema.xsd"/>
+            targetNamespace="urn:oval:v6:definitions:esx"
+            elementFormDefault="qualified" version="6.0">
+      <xsd:import namespace="urn:oval:v6:common" schemaLocation="oval-common-schema.xsd"/>
+      <xsd:import namespace="urn:oval:v6:definitions" schemaLocation="oval-definitions-schema.xsd"/>
       <xsd:annotation>
             <xsd:documentation>The following is a description of the elements, types, and attributes that compose the VMware ESX server specific tests found in Open Vulnerability and Assessment Language (OVAL). Each test is an extension of the standard test element defined in the Core Definition Schema. Through extension, each test inherits a set of elements and attributes that are shared amongst all OVAL tests. Each test is described in detail and should provide the information necessary to understand what each element and attribute represents. This document is intended for developers and assumes some familiarity with XML. A high level description of the interaction between the different tests and their relationship to the Core Definition Schema is not outlined here.</xsd:documentation>
             <xsd:documentation>This schema was originally developed by Yuzheng Zhou and Todd Dolinsky at Hewlett-Packard. The OVAL Schema is maintained by the OVAL Community. For more information, including how to get involved in the project and how to submit change requests, please visit the OVAL website at https://github.com/OVAL-Community/.</xsd:documentation>
             <xsd:appinfo>
                   <schema>VMware ESX server Definition</schema>
-                  <version>5.12</version>
-                  <date>11/29/2024 09:00:00 AM</date>
+                  <version>6.0</version>
+                  <date>1/1/2025 09:00:00 AM</date>
                   <terms_of_use>This software is an open standard developed by multiple parties, including the United States Government (Government). The Government hereby grants you a non-exclusive, royalty-free, worldwide license to use, modify, and/or reproduce the software for any lawful purpose provided that you reproduce this License/Disclaimer language with any use/modification/copy of the software. The Government assumes no responsibility whatsoever for this software's use by other parties, and the software is provided "AS IS" without warranty or guarantee of any kind, express or implied, including, but not limited to, the warranties of merchantability, fitness for a particular purpose, and noninfringement. In no event shall the Government be liable for any claim, damages or other liability, whether in an action of contract, tort or other dealings in the software. The Government has no obligation hereunder to provide maintenance, support, updates, enhancements, or modifications to the software. Users may submit proposals and/or updates regarding the software, which proposals and/or updates the Government, at its sole discretion, can choose to incorporate into the software. Proposals and/or updates submitted to the Government by users must be accompanied by a license to such proposals and/or updates that is no more restrictive than this License/Disclaimer.</terms_of_use>
-                  <sch:ns prefix="oval-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5"/>
-                  <sch:ns prefix="esx-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5#esx"/>
+                  <sch:ns prefix="oval-def" urn="urn:oval:v6:definitions"/>
+                  <sch:ns prefix="esx-def" urn="urn:oval:v6:definitions:esx"/>
                   <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
             </xsd:appinfo>
       </xsd:annotation>
@@ -33,7 +33,7 @@
                               <oval:test>patch56_test</oval:test>
                               <oval:object>patch56_object</oval:object>
                               <oval:state>patch56_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#esx">patch_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:esx">patch_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -77,7 +77,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#esx') and ($state_name='patch56_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:esx') and ($state_name='patch56_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -170,7 +170,7 @@
                               <oval:test>patch_test</oval:test>
                               <oval:object>patch_object</oval:object>
                               <oval:state>patch_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#esx">patch_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:esx">patch_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -310,7 +310,7 @@
                               <oval:test>version_test</oval:test>
                               <oval:object>version_object</oval:object>
                               <oval:state>version_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#esx">version_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:esx">version_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -388,7 +388,7 @@
                               <oval:test>visdkmanagedobject_test</oval:test>
                               <oval:object>visdkmanagedobject_object</oval:object>
                               <oval:state>visdkmanagedobject_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#esx">visdkmanagedobject_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:esx">visdkmanagedobject_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -432,7 +432,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#esx') and ($state_name='visdkmanagedobject_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:esx') and ($state_name='visdkmanagedobject_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>

--- a/oval-schemas/esx-system-characteristics-schema.xsd
+++ b/oval-schemas/esx-system-characteristics-schema.xsd
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-            xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5"
-            xmlns:oval-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5"
-            xmlns:esx-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#esx"
+            xmlns:oval="urn:oval:v6:common"
+            xmlns:oval-sc="urn:oval:v6:system-characteristics"
+            xmlns:esx-sc="urn:oval:v6:system-characteristics:esx"
             xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-            targetNamespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#esx"
-            elementFormDefault="qualified" version="5.12">
-      <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-common-5" schemaLocation="oval-common-schema.xsd"/>
-      <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5" schemaLocation="oval-system-characteristics-schema.xsd"/>
+            targetNamespace="urn:oval:v6:system-characteristics:esx"
+            elementFormDefault="qualified" version="6.0">
+      <xsd:import namespace="urn:oval:v6:common" schemaLocation="oval-common-schema.xsd"/>
+      <xsd:import namespace="urn:oval:v6:system-characteristics" schemaLocation="oval-system-characteristics-schema.xsd"/>
       <xsd:annotation>
             <xsd:documentation>The following is a description of the elements, types, and attributes that compose the VMware ESX server specific system characteristic items found in Open Vulnerability and Assessment Language (OVAL). Each item is an extension of the standard test element defined in the Core Definition Schema. Through extension, each test inherits a set of elements and attributes that are shared amongst all OVAL tests. Each test is described in detail and should provide the information necessary to understand what each element and attribute represents. This document is intended for developers and assumes some familiarity with XML. A high level description of the interaction between the different tests and their relationship to the Core Definition Schema is not outlined here.</xsd:documentation>
             <xsd:documentation>This schema was originally developed by Yuzheng Zhou and Todd Dolinsky at Hewlett-Packard. The OVAL Schema is maintained by the OVAL Community. For more information, including how to get involved in the project and how to submit change requests, please visit the OVAL website at https://github.com/OVAL-Community/.</xsd:documentation>
             <xsd:appinfo>
                   <schema>VMware ESX server System Characteristics</schema>
-                  <version>5.12</version>
-                  <date>11/29/2024 09:00:00 AM</date>
+                  <version>6.0</version>
+                  <date>1/1/2025 09:00:00 AM</date>
                   <terms_of_use>This software is an open standard developed by multiple parties, including the United States Government (Government). The Government hereby grants you a non-exclusive, royalty-free, worldwide license to use, modify, and/or reproduce the software for any lawful purpose provided that you reproduce this License/Disclaimer language with any use/modification/copy of the software. The Government assumes no responsibility whatsoever for this software's use by other parties, and the software is provided "AS IS" without warranty or guarantee of any kind, express or implied, including, but not limited to, the warranties of merchantability, fitness for a particular purpose, and noninfringement. In no event shall the Government be liable for any claim, damages or other liability, whether in an action of contract, tort or other dealings in the software. The Government has no obligation hereunder to provide maintenance, support, updates, enhancements, or modifications to the software. Users may submit proposals and/or updates regarding the software, which proposals and/or updates the Government, at its sole discretion, can choose to incorporate into the software. Proposals and/or updates submitted to the Government by users must be accompanied by a license to such proposals and/or updates that is no more restrictive than this License/Disclaimer.</terms_of_use>
-                  <sch:ns prefix="oval-sc" uri="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5"/>
-                  <sch:ns prefix="esx-sc" uri="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#esx"/>
+                  <sch:ns prefix="oval-sc" urn="urn:oval:v6:system-characteristics"/>
+                  <sch:ns prefix="esx-sc" urn="urn:oval:v6:system-characteristics:esx"/>
                 <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
             </xsd:appinfo>
       </xsd:annotation>

--- a/oval-schemas/evaluation-ids.xsd
+++ b/oval-schemas/evaluation-ids.xsd
@@ -1,13 +1,13 @@
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
-    xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5" 
+    xmlns:oval="urn:oval:v6:common" 
     xmlns:evalids="http://oval.mitre.org/XMLSchema/ovaldi/evalids" targetNamespace="http://oval.mitre.org/XMLSchema/ovaldi/evalids" elementFormDefault="qualified">
-    <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-common-5"/>
+    <xsd:import namespace="urn:oval:v6:common"/>
     <xsd:annotation>
         <xsd:documentation>This schema defines an xml format for inputing a set of OVAL Definition ids into the reference OVAL Interpreter for evaluation.</xsd:documentation>
         <xsd:appinfo>
             <schema>OVAL Definition Interpreter - Evaluation Id Schema</schema>
-            <version>5.12</version>
-            <date>11/29/2024 09:00:00 AM</date>
+            <version>6.0</version>
+            <date>1/1/2025 09:00:00 AM</date>
             <terms_of_use>This software is an open standard developed by multiple parties, including the United States Government (Government). The Government hereby grants you a non-exclusive, royalty-free, worldwide license to use, modify, and/or reproduce the software for any lawful purpose provided that you reproduce this License/Disclaimer language with any use/modification/copy of the software. The Government assumes no responsibility whatsoever for this software's use by other parties, and the software is provided "AS IS" without warranty or guarantee of any kind, express or implied, including, but not limited to, the warranties of merchantability, fitness for a particular purpose, and noninfringement. In no event shall the Government be liable for any claim, damages or other liability, whether in an action of contract, tort or other dealings in the software. The Government has no obligation hereunder to provide maintenance, support, updates, enhancements, or modifications to the software. Users may submit proposals and/or updates regarding the software, which proposals and/or updates the Government, at its sole discretion, can choose to incorporate into the software. Proposals and/or updates submitted to the Government by users must be accompanied by a license to such proposals and/or updates that is no more restrictive than this License/Disclaimer.</terms_of_use>
         </xsd:appinfo>
     </xsd:annotation>

--- a/oval-schemas/freebsd-definitions-schema.xsd
+++ b/oval-schemas/freebsd-definitions-schema.xsd
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-            xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5"
-            xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5"
-            xmlns:freebsd-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#freebsd"
+            xmlns:oval="urn:oval:v6:common"
+            xmlns:oval-def="urn:oval:v6:definitions"
+            xmlns:freebsd-def="urn:oval:v6:definitions:freebsd"
             xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-            targetNamespace="http://oval.mitre.org/XMLSchema/oval-definitions-5#freebsd"
-            elementFormDefault="qualified" version="5.12">
-      <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-definitions-5" schemaLocation="oval-definitions-schema.xsd"/>
-      <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-common-5" schemaLocation="oval-common-schema.xsd"/>
+            targetNamespace="urn:oval:v6:definitions:freebsd"
+            elementFormDefault="qualified" version="6.0">
+      <xsd:import namespace="urn:oval:v6:definitions" schemaLocation="oval-definitions-schema.xsd"/>
+      <xsd:import namespace="urn:oval:v6:common" schemaLocation="oval-common-schema.xsd"/>
       <xsd:annotation>
             <xsd:documentation>The following is a description of the elements, types, and attributes that compose the FreeBSD specific tests found in Open Vulnerability and Assessment Language (OVAL). Each test is an extension of the standard test element defined in the Core Definition Schema. Through extension, each test inherits a set of elements and attributes that are shared amongst all OVAL tests. Each test is described in detail and should provide the information necessary to understand what each element and attribute represents. This document is intended for developers and assumes some familiarity with XML. A high level description of the interaction between the different tests and their relationship to the Core Definition Schema is not outlined here.</xsd:documentation>
             <xsd:documentation>The OVAL Schema is maintained by the OVAL Community. For more information, including how to get involved in the project and how to submit change requests, please visit the OVAL website at https://github.com/OVAL-Community/.</xsd:documentation>
             <xsd:appinfo>
                   <schema>FreeBSD Definition</schema>
-                  <version>5.12</version>
-                  <date>11/29/2024 09:00:00 AM</date>
+                  <version>6.0</version>
+                  <date>1/1/2025 09:00:00 AM</date>
                   <terms_of_use>This software is an open standard developed by multiple parties, including the United States Government (Government). The Government hereby grants you a non-exclusive, royalty-free, worldwide license to use, modify, and/or reproduce the software for any lawful purpose provided that you reproduce this License/Disclaimer language with any use/modification/copy of the software. The Government assumes no responsibility whatsoever for this software's use by other parties, and the software is provided "AS IS" without warranty or guarantee of any kind, express or implied, including, but not limited to, the warranties of merchantability, fitness for a particular purpose, and noninfringement. In no event shall the Government be liable for any claim, damages or other liability, whether in an action of contract, tort or other dealings in the software. The Government has no obligation hereunder to provide maintenance, support, updates, enhancements, or modifications to the software. Users may submit proposals and/or updates regarding the software, which proposals and/or updates the Government, at its sole discretion, can choose to incorporate into the software. Proposals and/or updates submitted to the Government by users must be accompanied by a license to such proposals and/or updates that is no more restrictive than this License/Disclaimer.</terms_of_use>
-                  <sch:ns prefix="oval-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5"/>
-                  <sch:ns prefix="freebsd-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5#freebsd"/>
-                  <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-common-5" schemaLocation="oval-common-schema.xsd"/>
+                  <sch:ns prefix="oval-def" urn="urn:oval:v6:definitions"/>
+                  <sch:ns prefix="freebsd-def" urn="urn:oval:v6:definitions:freebsd"/>
+                  <xsd:import namespace="urn:oval:v6:common" schemaLocation="oval-common-schema.xsd"/>
                   <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
             </xsd:appinfo>
       </xsd:annotation>
@@ -33,7 +33,7 @@
                               <oval:test>portinfo_test</oval:test>
                               <oval:object>portinfo_object</oval:object>
                               <oval:state>portinfo_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#freebsd">portinfo_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:freebsd">portinfo_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -77,7 +77,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#freebsd') and ($state_name='portinfo_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:freebsd') and ($state_name='portinfo_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>

--- a/oval-schemas/freebsd-system-characteristics-schema.xsd
+++ b/oval-schemas/freebsd-system-characteristics-schema.xsd
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-            xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5"
-            xmlns:oval-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5"
-            xmlns:freebsd-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#freebsd"
+            xmlns:oval="urn:oval:v6:common"
+            xmlns:oval-sc="urn:oval:v6:system-characteristics"
+            xmlns:freebsd-sc="urn:oval:v6:system-characteristics:freebsd"
             xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-            targetNamespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#freebsd"
-            elementFormDefault="qualified" version="5.12">
-     <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5" schemaLocation="oval-system-characteristics-schema.xsd"/>
-     <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-common-5" schemaLocation="oval-common-schema.xsd"/>
+            targetNamespace="urn:oval:v6:system-characteristics:freebsd"
+            elementFormDefault="qualified" version="6.0">
+     <xsd:import namespace="urn:oval:v6:system-characteristics" schemaLocation="oval-system-characteristics-schema.xsd"/>
+     <xsd:import namespace="urn:oval:v6:common" schemaLocation="oval-common-schema.xsd"/>
      <xsd:annotation>
           <xsd:documentation>The following is a description of the elements, types, and attributes that compose the FreeBSD specific system characteristic items found in Open Vulnerability and Assessment Language (OVAL). Each item is an extension of the standard test element defined in the Core Definition Schema. Through extension, each test inherits a set of elements and attributes that are shared amongst all OVAL tests. Each test is described in detail and should provide the information necessary to understand what each element and attribute represents. This document is intended for developers and assumes some familiarity with XML. A high level description of the interaction between the different tests and their relationship to the Core Definition Schema is not outlined here.</xsd:documentation>
           <xsd:documentation>The OVAL Schema is maintained by the OVAL Community. For more information, including how to get involved in the project and how to submit change requests, please visit the OVAL website at https://github.com/OVAL-Community/.</xsd:documentation>
           <xsd:appinfo>
                <schema>FreeBSD System Characteristics</schema>
-               <version>5.12</version>
-               <date>11/29/2024 09:00:00 AM</date>
+               <version>6.0</version>
+               <date>1/1/2025 09:00:00 AM</date>
                 <terms_of_use>This software is an open standard developed by multiple parties, including the United States Government (Government). The Government hereby grants you a non-exclusive, royalty-free, worldwide license to use, modify, and/or reproduce the software for any lawful purpose provided that you reproduce this License/Disclaimer language with any use/modification/copy of the software. The Government assumes no responsibility whatsoever for this software's use by other parties, and the software is provided "AS IS" without warranty or guarantee of any kind, express or implied, including, but not limited to, the warranties of merchantability, fitness for a particular purpose, and noninfringement. In no event shall the Government be liable for any claim, damages or other liability, whether in an action of contract, tort or other dealings in the software. The Government has no obligation hereunder to provide maintenance, support, updates, enhancements, or modifications to the software. Users may submit proposals and/or updates regarding the software, which proposals and/or updates the Government, at its sole discretion, can choose to incorporate into the software. Proposals and/or updates submitted to the Government by users must be accompanied by a license to such proposals and/or updates that is no more restrictive than this License/Disclaimer.</terms_of_use>
-               <sch:ns prefix="oval-sc" uri="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5"/>
-               <sch:ns prefix="freebsd-sc" uri="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#freebsd"/>
+               <sch:ns prefix="oval-sc" urn="urn:oval:v6:system-characteristics"/>
+               <sch:ns prefix="freebsd-sc" urn="urn:oval:v6:system-characteristics:freebsd"/>
               <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
           </xsd:appinfo>
      </xsd:annotation>

--- a/oval-schemas/hpux-definitions-schema.xsd
+++ b/oval-schemas/hpux-definitions-schema.xsd
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-            xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5"
-            xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5"
-            xmlns:hpux-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#hpux"
+            xmlns:oval="urn:oval:v6:common"
+            xmlns:oval-def="urn:oval:v6:definitions"
+            xmlns:hpux-def="urn:oval:v6:definitions:hpux"
             xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-            targetNamespace="http://oval.mitre.org/XMLSchema/oval-definitions-5#hpux"
-            elementFormDefault="qualified" version="5.12">
-      <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-common-5" schemaLocation="oval-common-schema.xsd"/>
-      <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-definitions-5" schemaLocation="oval-definitions-schema.xsd"/>
+            targetNamespace="urn:oval:v6:definitions:hpux"
+            elementFormDefault="qualified" version="6.0">
+      <xsd:import namespace="urn:oval:v6:common" schemaLocation="oval-common-schema.xsd"/>
+      <xsd:import namespace="urn:oval:v6:definitions" schemaLocation="oval-definitions-schema.xsd"/>
       <xsd:annotation>
             <xsd:documentation>The following is a description of the elements, types, and attributes that compose the HP-UX specific tests found in Open Vulnerability and Assessment Language (OVAL). Each test is an extension of the standard test element defined in the Core Definition Schema. Through extension, each test inherits a set of elements and attributes that are shared amongst all OVAL tests. Each test is described in detail and should provide the information necessary to understand what each element and attribute represents. This document is intended for developers and assumes some familiarity with XML. A high level description of the interaction between the different tests and their relationship to the Core Definition Schema is not outlined here.</xsd:documentation>
             <xsd:documentation>The OVAL Schema is maintained by the OVAL Community. For more information, including how to get involved in the project and how to submit change requests, please visit the OVAL website at https://github.com/OVAL-Community/.</xsd:documentation>
             <xsd:appinfo>
                   <schema>HP-UX Definition</schema>
-                  <version>5.12</version>
-                  <date>11/29/2024 09:00:00 AM</date>
+                  <version>6.0</version>
+                  <date>1/1/2025 09:00:00 AM</date>
                   <terms_of_use>This software is an open standard developed by multiple parties, including the United States Government (Government). The Government hereby grants you a non-exclusive, royalty-free, worldwide license to use, modify, and/or reproduce the software for any lawful purpose provided that you reproduce this License/Disclaimer language with any use/modification/copy of the software. The Government assumes no responsibility whatsoever for this software's use by other parties, and the software is provided "AS IS" without warranty or guarantee of any kind, express or implied, including, but not limited to, the warranties of merchantability, fitness for a particular purpose, and noninfringement. In no event shall the Government be liable for any claim, damages or other liability, whether in an action of contract, tort or other dealings in the software. The Government has no obligation hereunder to provide maintenance, support, updates, enhancements, or modifications to the software. Users may submit proposals and/or updates regarding the software, which proposals and/or updates the Government, at its sole discretion, can choose to incorporate into the software. Proposals and/or updates submitted to the Government by users must be accompanied by a license to such proposals and/or updates that is no more restrictive than this License/Disclaimer.</terms_of_use>
-                  <sch:ns prefix="oval-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5"/>
-                  <sch:ns prefix="hpux-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5#hpux"/>
+                  <sch:ns prefix="oval-def" urn="urn:oval:v6:definitions"/>
+                  <sch:ns prefix="hpux-def" urn="urn:oval:v6:definitions:hpux"/>
                   <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
             </xsd:appinfo>
       </xsd:annotation>
@@ -32,7 +32,7 @@
                               <oval:test>getconf_test</oval:test>
                               <oval:object>getconf_object</oval:object>
                               <oval:state>getconf_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#hpux">getconf_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:hpux">getconf_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -75,7 +75,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#hpux') and ($state_name='getconf_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:hpux') and ($state_name='getconf_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -144,7 +144,7 @@
                               <oval:test>ndd_test</oval:test>
                               <oval:object>ndd_object</oval:object>
                               <oval:state>ndd_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#hpux">ndd_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:hpux">ndd_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -187,7 +187,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#hpux') and ($state_name='ndd_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:hpux') and ($state_name='ndd_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -256,7 +256,7 @@
                               <oval:test>patch53_test</oval:test>
                               <oval:object>patch53_object</oval:object>
                               <oval:state>patch53_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#hpux">patch_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:hpux">patch_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -299,7 +299,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#hpux') and ($state_name='patch53_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:hpux') and ($state_name='patch53_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -387,7 +387,7 @@
                               <oval:test>patch_test</oval:test>
                               <oval:object>patch_object</oval:object>
                               <oval:state>patch_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#hpux">patch_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:hpux">patch_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -511,7 +511,7 @@
                               <oval:test>swlist_test</oval:test>
                               <oval:object>swlist_object</oval:object>
                               <oval:state>swlist_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#hpux">swlist_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:hpux">swlist_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -554,7 +554,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#hpux') and ($state_name='swlist_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:hpux') and ($state_name='swlist_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -647,7 +647,7 @@
                               <oval:test>trusted_test</oval:test>
                               <oval:object>trusted_object</oval:object>
                               <oval:state>trusted_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#hpux">trusted_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:hpux">trusted_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -690,7 +690,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#hpux') and ($state_name='trusted_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:hpux') and ($state_name='trusted_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>

--- a/oval-schemas/hpux-system-characteristics-schema.xsd
+++ b/oval-schemas/hpux-system-characteristics-schema.xsd
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-            xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5"
-            xmlns:oval-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5"
-            xmlns:hpux-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#hpux"
+            xmlns:oval="urn:oval:v6:common"
+            xmlns:oval-sc="urn:oval:v6:system-characteristics"
+            xmlns:hpux-sc="urn:oval:v6:system-characteristics:hpux"
             xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-            targetNamespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#hpux"
-            elementFormDefault="qualified" version="5.12">
-	<xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5" schemaLocation="oval-system-characteristics-schema.xsd"/>
-	<xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-common-5" schemaLocation="oval-common-schema.xsd"/>     
+            targetNamespace="urn:oval:v6:system-characteristics:hpux"
+            elementFormDefault="qualified" version="6.0">
+	<xsd:import namespace="urn:oval:v6:system-characteristics" schemaLocation="oval-system-characteristics-schema.xsd"/>
+	<xsd:import namespace="urn:oval:v6:common" schemaLocation="oval-common-schema.xsd"/>     
 	<xsd:annotation>
 		<xsd:documentation>The following is a description of the elements, types, and attributes that compose the HP-UX specific system characteristic items found in Open Vulnerability and Assessment Language (OVAL).  Each item is an extension of the standard item element defined in the Core System Characteristic Schema.  Through extension, each item inherits a set of elements and attributes that are shared amongst all OVAL Items.  Each item is described in detail and should provide the information necessary to understand what each element and attribute represents.  This document is intended for developers and assumes some familiarity with XML.  A high level description of the interaction between the different tests and their relationship to the Core System Characteristic Schema is not outlined here.</xsd:documentation>
 		<xsd:documentation>The OVAL Schema is maintained by the OVAL Community. For more information, including how to get involved in the project and how to submit change requests, please visit the OVAL website at https://github.com/OVAL-Community/.</xsd:documentation>
 		<xsd:appinfo>
 			<schema>HP-UX System Characteristics</schema>
-		     <version>5.12</version>
-		     <date>11/29/2024 09:00:00 AM</date>
+		     <version>6.0</version>
+		     <date>1/1/2025 09:00:00 AM</date>
 		      <terms_of_use>This software is an open standard developed by multiple parties, including the United States Government (Government). The Government hereby grants you a non-exclusive, royalty-free, worldwide license to use, modify, and/or reproduce the software for any lawful purpose provided that you reproduce this License/Disclaimer language with any use/modification/copy of the software. The Government assumes no responsibility whatsoever for this software's use by other parties, and the software is provided "AS IS" without warranty or guarantee of any kind, express or implied, including, but not limited to, the warranties of merchantability, fitness for a particular purpose, and noninfringement. In no event shall the Government be liable for any claim, damages or other liability, whether in an action of contract, tort or other dealings in the software. The Government has no obligation hereunder to provide maintenance, support, updates, enhancements, or modifications to the software. Users may submit proposals and/or updates regarding the software, which proposals and/or updates the Government, at its sole discretion, can choose to incorporate into the software. Proposals and/or updates submitted to the Government by users must be accompanied by a license to such proposals and/or updates that is no more restrictive than this License/Disclaimer.</terms_of_use>
-			<sch:ns prefix="oval-sc" uri="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5"/>
-			<sch:ns prefix="hpux-sc" uri="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#hpux"/>
+			<sch:ns prefix="oval-sc" urn="urn:oval:v6:system-characteristics"/>
+			<sch:ns prefix="hpux-sc" urn="urn:oval:v6:system-characteristics:hpux"/>
 		    <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
 		</xsd:appinfo>
 	</xsd:annotation>

--- a/oval-schemas/independent-definitions-schema.xsd
+++ b/oval-schemas/independent-definitions-schema.xsd
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-            xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5"
-            xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5"
-            xmlns:ind-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent"
+            xmlns:oval="urn:oval:v6:common"
+            xmlns:oval-def="urn:oval:v6:definitions"
+            xmlns:ind-def="urn:oval:v6:definitions:independent"
             xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-            targetNamespace="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent"
-            elementFormDefault="qualified" version="5.12">
-      <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-common-5" schemaLocation="oval-common-schema.xsd"/>
-      <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-definitions-5" schemaLocation="oval-definitions-schema.xsd"/>
+            targetNamespace="urn:oval:v6:definitions:independent"
+            elementFormDefault="qualified" version="6.0">
+      <xsd:import namespace="urn:oval:v6:common" schemaLocation="oval-common-schema.xsd"/>
+      <xsd:import namespace="urn:oval:v6:definitions" schemaLocation="oval-definitions-schema.xsd"/>
       <xsd:annotation>
             <xsd:documentation>The following is a description of the elements, types, and attributes that compose the tests found in Open Vulnerability and Assessment Language (OVAL) that are independent of a specific piece of software. Each test is described in detail and should provide the information necessary to understand what each element and attribute represents. This document is intended for developers and assumes some familiarity with XML. A high level description of the interaction between the different tests and their relationship to the Core Definition Schema is not outlined here.</xsd:documentation>
             <xsd:documentation>The OVAL Schema is maintained by the OVAL Community. For more information, including how to get involved in the project and how to submit change requests, please visit the OVAL website at https://github.com/OVAL-Community/.</xsd:documentation>
             <xsd:appinfo>
                   <schema>Independent Definition</schema>
-                  <version>5.12</version>
-                  <date>11/29/2024 09:00:00 AM</date>
+                  <version>6.0</version>
+                  <date>1/1/2025 09:00:00 AM</date>
                   <terms_of_use>This software is an open standard developed by multiple parties, including the United States Government (Government). The Government hereby grants you a non-exclusive, royalty-free, worldwide license to use, modify, and/or reproduce the software for any lawful purpose provided that you reproduce this License/Disclaimer language with any use/modification/copy of the software. The Government assumes no responsibility whatsoever for this software's use by other parties, and the software is provided "AS IS" without warranty or guarantee of any kind, express or implied, including, but not limited to, the warranties of merchantability, fitness for a particular purpose, and noninfringement. In no event shall the Government be liable for any claim, damages or other liability, whether in an action of contract, tort or other dealings in the software. The Government has no obligation hereunder to provide maintenance, support, updates, enhancements, or modifications to the software. Users may submit proposals and/or updates regarding the software, which proposals and/or updates the Government, at its sole discretion, can choose to incorporate into the software. Proposals and/or updates submitted to the Government by users must be accompanied by a license to such proposals and/or updates that is no more restrictive than this License/Disclaimer.</terms_of_use>
-                  <sch:ns prefix="oval-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5"/>
-                  <sch:ns prefix="ind-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent"/>
+                  <sch:ns prefix="oval-def" urn="urn:oval:v6:definitions"/>
+                  <sch:ns prefix="ind-def" urn="urn:oval:v6:definitions:independent"/>
                   <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
             </xsd:appinfo>
       </xsd:annotation>
@@ -33,7 +33,7 @@
                               <oval:test>family_test</oval:test>
                               <oval:object>family_object</oval:object>
                               <oval:state>family_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#independent">family_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:independent">family_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -97,7 +97,7 @@
                               <oval:test>filehash_test</oval:test>
                               <oval:object>filehash_object</oval:object>
                               <oval:state>filehash_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#independent">filehash_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:independent">filehash_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -282,7 +282,7 @@
                               <oval:test>filehash58_test</oval:test>
                               <oval:object>filehash58_object</oval:object>
                               <oval:state>filehash58_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#independent">filehash58_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:independent">filehash58_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -322,7 +322,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#independent') and ($state_name='filehash58_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:independent') and ($state_name='filehash58_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -450,7 +450,7 @@
                               <oval:test>environmentvariable_test</oval:test>
                               <oval:object>environmentvariable_object</oval:object>
                               <oval:state>environmentvariable_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#independent">environmentvariable_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:independent">environmentvariable_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -566,7 +566,7 @@
                               <oval:test>environmentvariable58_test</oval:test>
                               <oval:object>environmentvariable58_object</oval:object>
                               <oval:state>environmentvariable58_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#independent">environmentvariable58_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:independent">environmentvariable58_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -603,7 +603,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#independent') and ($state_name='environmentvariable58_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:independent') and ($state_name='environmentvariable58_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -672,7 +672,7 @@
                               <oval:test>ldap_test</oval:test>
                               <oval:object>ldap_object</oval:object>
                               <oval:state>ldap_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#independent">ldap_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:independent">ldap_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -809,7 +809,7 @@
                               <oval:test>ldap57_test</oval:test>
                               <oval:object>ldap57_object</oval:object>
                               <oval:state>ldap57_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#independent">ldap57_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:independent">ldap57_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -871,7 +871,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#independent') and ($state_name='ldap57_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:independent') and ($state_name='ldap57_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -992,7 +992,7 @@ IMPORTANT! - Since this test requires the running of code supplied by content an
                               <oval:test>shellcommand_test</oval:test>
                               <oval:object>shellcommand_object</oval:object>
                               <oval:state>shellcommand_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#independent">shellcommand_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:independent">shellcommand_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -1033,7 +1033,7 @@ The evaluation of the object should always produce one item. If the command exec
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#independent') and ($state_name='shellcommand_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:independent') and ($state_name='shellcommand_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -1150,7 +1150,7 @@ A subexpression (using parentheses) can call out a piece of the matched stdout_l
                               <oval:test>sql_test</oval:test>
                               <oval:object>sql_object</oval:object>
                               <oval:state>sql_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#independent">sql_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:independent">sql_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -1326,7 +1326,7 @@ A subexpression (using parentheses) can call out a piece of the matched stdout_l
                               <oval:test>sql57_test</oval:test>
                               <oval:object>sql57_object</oval:object>
                               <oval:state>sql57_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#independent">sql57_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:independent">sql57_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -1375,7 +1375,7 @@ A subexpression (using parentheses) can call out a piece of the matched stdout_l
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#independent') and ($state_name='sql57_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:independent') and ($state_name='sql57_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -1528,7 +1528,7 @@ A subexpression (using parentheses) can call out a piece of the matched stdout_l
                               <oval:test>sql512_test</oval:test>
                               <oval:object>sql512_object</oval:object>
                               <oval:state>sql512_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#independent">sql512_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:independent">sql512_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -1565,7 +1565,7 @@ A subexpression (using parentheses) can call out a piece of the matched stdout_l
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#independent') and ($state_name='sql512_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:independent') and ($state_name='sql512_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -1705,7 +1705,7 @@ SERVERPROPERTY('IsClustered') AS [is_clustered]
                               <oval:test>textfilecontent54_test</oval:test>
                               <oval:object>textfilecontent54_object</oval:object>
                               <oval:state>textfilecontent54_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#independent">textfilecontent_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:independent">textfilecontent_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -1744,7 +1744,7 @@ SERVERPROPERTY('IsClustered') AS [is_clustered]
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#independent') and ($state_name='textfilecontent54_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:independent') and ($state_name='textfilecontent54_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -1930,7 +1930,7 @@ SERVERPROPERTY('IsClustered') AS [is_clustered]
                               <oval:test>textfilecontent_test</oval:test>
                               <oval:object>textfilecontent_object</oval:object>
                               <oval:state>textfilecontent_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#independent">textfilecontent_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:independent">textfilecontent_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -2102,7 +2102,7 @@ SERVERPROPERTY('IsClustered') AS [is_clustered]
                               <oval:test>variable_test</oval:test>
                               <oval:object>variable_object</oval:object>
                               <oval:state>variable_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#independent">variable_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:independent">variable_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -2139,7 +2139,7 @@ SERVERPROPERTY('IsClustered') AS [is_clustered]
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#independent') and ($state_name='variable_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:independent') and ($state_name='variable_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -2224,7 +2224,7 @@ SERVERPROPERTY('IsClustered') AS [is_clustered]
                               <oval:test>xmlfilecontent_test</oval:test>
                               <oval:object>xmlfilecontent_object</oval:object>
                               <oval:state>xmlfilecontent_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#independent">xmlfilecontent_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:independent">xmlfilecontent_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -2263,7 +2263,7 @@ SERVERPROPERTY('IsClustered') AS [is_clustered]
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#independent') and ($state_name='xmlfilecontent_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:independent') and ($state_name='xmlfilecontent_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -2398,7 +2398,7 @@ SERVERPROPERTY('IsClustered') AS [is_clustered]
                               <oval:test>yamlfilecontent_test</oval:test>
                               <oval:object>yamlfilecontent_object</oval:object>
                               <oval:state>yamlfilecontent_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#independent">yamlfilecontent_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:independent">yamlfilecontent_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -2437,7 +2437,7 @@ SERVERPROPERTY('IsClustered') AS [is_clustered]
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#independent') and ($state_name='yamlfilecontent_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:independent') and ($state_name='yamlfilecontent_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>

--- a/oval-schemas/independent-system-characteristics-schema.xsd
+++ b/oval-schemas/independent-system-characteristics-schema.xsd
@@ -1,22 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-            xmlns:oval-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5"
-            xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5"
-            xmlns:ind-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#independent"
+            xmlns:oval-sc="urn:oval:v6:system-characteristics"
+            xmlns:oval="urn:oval:v6:common"
+            xmlns:ind-sc="urn:oval:v6:system-characteristics:independent"
             xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-            targetNamespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#independent"
-            elementFormDefault="qualified" version="5.12">
-     <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5" schemaLocation="oval-system-characteristics-schema.xsd"/>
+            targetNamespace="urn:oval:v6:system-characteristics:independent"
+            elementFormDefault="qualified" version="6.0">
+     <xsd:import namespace="urn:oval:v6:system-characteristics" schemaLocation="oval-system-characteristics-schema.xsd"/>
      <xsd:annotation>
           <xsd:documentation>This document outlines the items of the OVAL System Characteristics XML schema that are independent of any specific family or platform. Each iten is an extention of a basic System Characteristics item defined in the core System Characteristics XML schema.</xsd:documentation>
           <xsd:documentation>The OVAL Schema is maintained by the OVAL Community. For more information, including how to get involved in the project and how to submit change requests, please visit the OVAL website at https://github.com/OVAL-Community/.</xsd:documentation>
           <xsd:appinfo>
                <schema>Independent System Characteristics</schema>
-               <version>5.12</version>
-               <date>11/29/2024 09:00:00 AM</date>
+               <version>6.0</version>
+               <date>1/1/2025 09:00:00 AM</date>
                <terms_of_use>This software is an open standard developed by multiple parties, including the United States Government (Government). The Government hereby grants you a non-exclusive, royalty-free, worldwide license to use, modify, and/or reproduce the software for any lawful purpose provided that you reproduce this License/Disclaimer language with any use/modification/copy of the software. The Government assumes no responsibility whatsoever for this software's use by other parties, and the software is provided "AS IS" without warranty or guarantee of any kind, express or implied, including, but not limited to, the warranties of merchantability, fitness for a particular purpose, and noninfringement. In no event shall the Government be liable for any claim, damages or other liability, whether in an action of contract, tort or other dealings in the software. The Government has no obligation hereunder to provide maintenance, support, updates, enhancements, or modifications to the software. Users may submit proposals and/or updates regarding the software, which proposals and/or updates the Government, at its sole discretion, can choose to incorporate into the software. Proposals and/or updates submitted to the Government by users must be accompanied by a license to such proposals and/or updates that is no more restrictive than this License/Disclaimer.</terms_of_use>
-               <sch:ns prefix="oval-sc" uri="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5"/>
-               <sch:ns prefix="ind-sc" uri="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#independent"/>
+               <sch:ns prefix="oval-sc" urn="urn:oval:v6:system-characteristics"/>
+               <sch:ns prefix="ind-sc" urn="urn:oval:v6:system-characteristics:independent"/>
               <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
           </xsd:appinfo>
      </xsd:annotation>

--- a/oval-schemas/ios-definitions-schema.xsd
+++ b/oval-schemas/ios-definitions-schema.xsd
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-            xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5"
-            xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5"
-            xmlns:ios-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#ios"
+            xmlns:oval="urn:oval:v6:common"
+            xmlns:oval-def="urn:oval:v6:definitions"
+            xmlns:ios-def="urn:oval:v6:definitions:ios"
             xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-            targetNamespace="http://oval.mitre.org/XMLSchema/oval-definitions-5#ios"
-            elementFormDefault="qualified" version="5.12">
-      <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-definitions-5" schemaLocation="oval-definitions-schema.xsd"/>
-      <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-common-5" schemaLocation="oval-common-schema.xsd"/>
+            targetNamespace="urn:oval:v6:definitions:ios"
+            elementFormDefault="qualified" version="6.0">
+      <xsd:import namespace="urn:oval:v6:definitions" schemaLocation="oval-definitions-schema.xsd"/>
+      <xsd:import namespace="urn:oval:v6:common" schemaLocation="oval-common-schema.xsd"/>
       <xsd:annotation>
             <xsd:documentation>The following is a description of the elements, types, and attributes that compose the IOS specific tests found in Open Vulnerability and Assessment Language (OVAL). Each test is an extension of the standard test element defined in the Core Definition Schema. Through extension, each test inherits a set of elements and attributes that are shared amongst all OVAL tests. Each test is described in detail and should provide the information necessary to understand what each element and attribute represents. This document is intended for developers and assumes some familiarity with XML. A high level description of the interaction between the different tests and their relationship to the Core Definition Schema is not outlined here.</xsd:documentation>
             <xsd:documentation>The OVAL Schema is maintained by the OVAL Community. For more information, including how to get involved in the project and how to submit change requests, please visit the OVAL website at https://github.com/OVAL-Community/.</xsd:documentation>
             <xsd:appinfo>
                   <schema>IOS Definition</schema>
-                  <version>5.12</version>
-                  <date>11/29/2024 09:00:00 AM</date>
+                  <version>6.0</version>
+                  <date>1/1/2025 09:00:00 AM</date>
                   <terms_of_use>This software is an open standard developed by multiple parties, including the United States Government (Government). The Government hereby grants you a non-exclusive, royalty-free, worldwide license to use, modify, and/or reproduce the software for any lawful purpose provided that you reproduce this License/Disclaimer language with any use/modification/copy of the software. The Government assumes no responsibility whatsoever for this software's use by other parties, and the software is provided "AS IS" without warranty or guarantee of any kind, express or implied, including, but not limited to, the warranties of merchantability, fitness for a particular purpose, and noninfringement. In no event shall the Government be liable for any claim, damages or other liability, whether in an action of contract, tort or other dealings in the software. The Government has no obligation hereunder to provide maintenance, support, updates, enhancements, or modifications to the software. Users may submit proposals and/or updates regarding the software, which proposals and/or updates the Government, at its sole discretion, can choose to incorporate into the software. Proposals and/or updates submitted to the Government by users must be accompanied by a license to such proposals and/or updates that is no more restrictive than this License/Disclaimer.</terms_of_use>
-                  <sch:ns prefix="oval-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5"/>
-                  <sch:ns prefix="ios-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5#ios"/>
+                  <sch:ns prefix="oval-def" urn="urn:oval:v6:definitions"/>
+                  <sch:ns prefix="ios-def" urn="urn:oval:v6:definitions:ios"/>
                   <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
             </xsd:appinfo>
       </xsd:annotation>
@@ -32,7 +32,7 @@
                               <oval:test>acl_test</oval:test>
                               <oval:object>acl_object</oval:object>
                               <oval:state>acl_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#ios">acl_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:ios">acl_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -76,7 +76,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#ios') and ($state_name='acl_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type.</sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:ios') and ($state_name='acl_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type.</sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -165,7 +165,7 @@
                               <oval:test>bgpneighbor_test</oval:test>
                               <oval:object>bgpneighbor_object</oval:object>
                               <oval:state>bgpneighbor_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#ios">bgpneighbor_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:ios">bgpneighbor_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -203,7 +203,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#ios') and ($state_name='bgpneighbor_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type.</sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:ios') and ($state_name='bgpneighbor_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type.</sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -262,7 +262,7 @@
                               <oval:test>global_test</oval:test>
                               <oval:object>global_object</oval:object>
                               <oval:state>global_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#ios">global_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:ios">global_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -299,7 +299,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#ios') and ($state_name='global_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:ios') and ($state_name='global_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -353,7 +353,7 @@
                               <oval:test>interface_test</oval:test>
                               <oval:object>interface_object</oval:object>
                               <oval:state>interface_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#ios">interface_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:ios">interface_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -391,7 +391,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#ios') and ($state_name='interface_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:ios') and ($state_name='interface_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -637,7 +637,7 @@
                               <oval:test>line_test</oval:test>
                               <oval:object>line_object</oval:object>
                               <oval:state>line_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#ios">line_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:ios">line_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -675,7 +675,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#ios') and ($state_name='line_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:ios') and ($state_name='line_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -734,7 +734,7 @@
                               <oval:test>router_test</oval:test>
                               <oval:object>router_object</oval:object>
                               <oval:state>router_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#ios">router_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:ios">router_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -778,7 +778,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#ios') and ($state_name='router_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type.</sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:ios') and ($state_name='router_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type.</sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -876,7 +876,7 @@
                               <oval:test>routingprotocolauthintf_test</oval:test>
                               <oval:object>routingprotocolauthintf_object</oval:object>
                               <oval:state>routingprotocolauthintf_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#ios">routingprotocolauthintf_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:ios">routingprotocolauthintf_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -914,7 +914,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#ios') and ($state_name='routingprotocolauthintf_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type.</sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:ios') and ($state_name='routingprotocolauthintf_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type.</sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -1013,7 +1013,7 @@
                               <oval:test>section_test</oval:test>
                               <oval:object>section_object</oval:object>
                               <oval:state>section_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#ios">section_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:ios">section_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -1051,7 +1051,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#ios') and ($state_name='section_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type.</sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:ios') and ($state_name='section_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type.</sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -1115,7 +1115,7 @@
                               <oval:test>snmp_test</oval:test>
                               <oval:object>snmp_object</oval:object>
                               <oval:state>snmp_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#ios">snmp_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:ios">snmp_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -1184,7 +1184,7 @@
                               <oval:test>snmpcommunity_test</oval:test>
                               <oval:object>snmpcommunity_object</oval:object>
                               <oval:state>snmpcommunity_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#ios">snmpcommunity_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:ios">snmpcommunity_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -1222,7 +1222,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#ios') and ($state_name='snmpcommunity_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type.</sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:ios') and ($state_name='snmpcommunity_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type.</sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -1296,7 +1296,7 @@
                               <oval:test>snmpgroup_test</oval:test>
                               <oval:object>snmpgroup_object</oval:object>
                               <oval:state>snmpgroup_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#ios">snmpgroup_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:ios">snmpgroup_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -1334,7 +1334,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#ios') and ($state_name='snmpgroup_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type.</sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:ios') and ($state_name='snmpgroup_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type.</sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -1423,7 +1423,7 @@
                               <oval:test>snmphost_test</oval:test>
                               <oval:object>snmphost_object</oval:object>
                               <oval:state>snmphost_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#ios">snmphost_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:ios">snmphost_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -1461,7 +1461,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#ios') and ($state_name='snmphost_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type.</sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:ios') and ($state_name='snmphost_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type.</sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -1535,7 +1535,7 @@
                               <oval:test>snmpuser_test</oval:test>
                               <oval:object>snmpuser_object</oval:object>
                               <oval:state>snmpuser_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#ios">snmpuser_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:ios">snmpuser_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -1573,7 +1573,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#ios') and ($state_name='snmpuser_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type.</sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:ios') and ($state_name='snmpuser_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type.</sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -1657,7 +1657,7 @@
                               <oval:test>snmpview_test</oval:test>
                               <oval:object>snmpview_object</oval:object>
                               <oval:state>snmpview_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#ios">snmpview_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:ios">snmpview_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -1701,7 +1701,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#ios') and ($state_name='snmpview_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type.</sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:ios') and ($state_name='snmpview_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type.</sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -1765,7 +1765,7 @@
                               <oval:test>tclsh_test</oval:test>
                               <oval:object>tclsh_object</oval:object>
                               <oval:state>tclsh_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#ios">tclsh_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:ios">tclsh_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -1835,7 +1835,7 @@
                               <oval:test>version55_test</oval:test>
                               <oval:object>version55_object</oval:object>
                               <oval:state>version55_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#ios">version_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:ios">version_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -1934,7 +1934,7 @@
                           <oval:test>version_test</oval:test>
                           <oval:object>version_object</oval:object>
                           <oval:state>version_state</oval:state>
-                          <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#ios">version_item</oval:item>
+                          <oval:item target_namespace="urn:oval:v6:system-characteristics:ios">version_item</oval:item>
                     </oval:element_mapping>
               </xsd:appinfo>
               <xsd:appinfo>

--- a/oval-schemas/ios-system-characteristics-schema.xsd
+++ b/oval-schemas/ios-system-characteristics-schema.xsd
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-            xmlns:oval-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5"
-            xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5"
-            xmlns:ios-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#ios"
+            xmlns:oval-sc="urn:oval:v6:system-characteristics"
+            xmlns:oval="urn:oval:v6:common"
+            xmlns:ios-sc="urn:oval:v6:system-characteristics:ios"
             xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-            targetNamespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#ios"
-            elementFormDefault="qualified" version="5.12">
-     <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5" schemaLocation="oval-system-characteristics-schema.xsd"/>
-     <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-common-5" schemaLocation="oval-common-schema.xsd"/>
+            targetNamespace="urn:oval:v6:system-characteristics:ios"
+            elementFormDefault="qualified" version="6.0">
+     <xsd:import namespace="urn:oval:v6:system-characteristics" schemaLocation="oval-system-characteristics-schema.xsd"/>
+     <xsd:import namespace="urn:oval:v6:common" schemaLocation="oval-common-schema.xsd"/>
      <xsd:annotation>
           <xsd:documentation>The following is a description of the elements, types, and attributes that compose the IOS specific system characteristic items found in Open Vulnerability and Assessment Language (OVAL). Each item is an extension of the standard item element defined in the Core System Characteristic Schema. Through extension, each item inherits a set of elements and attributes that are shared amongst all OVAL Items. Each item is described in detail and should provide the information necessary to understand what each element and attribute represents. This document is intended for developers and assumes some familiarity with XML. A high level description of the interaction between the different tests and their relationship to the Core System Characteristic Schema is not outlined here.</xsd:documentation>
           <xsd:documentation>The OVAL Schema is maintained by the OVAL Community. For more information, including how to get involved in the project and how to submit change requests, please visit the OVAL website at https://github.com/OVAL-Community/.</xsd:documentation>
           <xsd:appinfo>
                <schema>IOS Definition</schema>
-               <version>5.12</version>
-               <date>11/29/2024 09:00:00 AM</date>
+               <version>6.0</version>
+               <date>1/1/2025 09:00:00 AM</date>
                <terms_of_use>This software is an open standard developed by multiple parties, including the United States Government (Government). The Government hereby grants you a non-exclusive, royalty-free, worldwide license to use, modify, and/or reproduce the software for any lawful purpose provided that you reproduce this License/Disclaimer language with any use/modification/copy of the software. The Government assumes no responsibility whatsoever for this software's use by other parties, and the software is provided "AS IS" without warranty or guarantee of any kind, express or implied, including, but not limited to, the warranties of merchantability, fitness for a particular purpose, and noninfringement. In no event shall the Government be liable for any claim, damages or other liability, whether in an action of contract, tort or other dealings in the software. The Government has no obligation hereunder to provide maintenance, support, updates, enhancements, or modifications to the software. Users may submit proposals and/or updates regarding the software, which proposals and/or updates the Government, at its sole discretion, can choose to incorporate into the software. Proposals and/or updates submitted to the Government by users must be accompanied by a license to such proposals and/or updates that is no more restrictive than this License/Disclaimer.</terms_of_use>
-               <sch:ns prefix="oval-sc" uri="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5"/>
-               <sch:ns prefix="ios-sc" uri="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#ios"/>
+               <sch:ns prefix="oval-sc" urn="urn:oval:v6:system-characteristics"/>
+               <sch:ns prefix="ios-sc" urn="urn:oval:v6:system-characteristics:ios"/>
               <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
           </xsd:appinfo>
      </xsd:annotation>

--- a/oval-schemas/iosxe-definitions-schema.xsd
+++ b/oval-schemas/iosxe-definitions-schema.xsd
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-            xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5"
-            xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5"
-            xmlns:iosxe-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#iosxe"
+            xmlns:oval="urn:oval:v6:common"
+            xmlns:oval-def="urn:oval:v6:definitions"
+            xmlns:iosxe-def="urn:oval:v6:definitions:iosxe"
             xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-            targetNamespace="http://oval.mitre.org/XMLSchema/oval-definitions-5#iosxe"
-            elementFormDefault="qualified" version="5.12">
-    <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-definitions-5" schemaLocation="oval-definitions-schema.xsd"/>
-    <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-common-5" schemaLocation="oval-common-schema.xsd"/>
+            targetNamespace="urn:oval:v6:definitions:iosxe"
+            elementFormDefault="qualified" version="6.0">
+    <xsd:import namespace="urn:oval:v6:definitions" schemaLocation="oval-definitions-schema.xsd"/>
+    <xsd:import namespace="urn:oval:v6:common" schemaLocation="oval-common-schema.xsd"/>
     <xsd:annotation>
         <xsd:documentation>The following is a description of the elements, types, and attributes that compose the IOS-XE specific tests found in Open Vulnerability and Assessment Language (OVAL). Each test is an extension of the standard test element defined in the Core Definition Schema. Through extension, each test inherits a set of elements and attributes that are shared amongst all OVAL tests. Each test is described in detail and should provide the information necessary to understand what each element and attribute represents. This document is intended for developers and assumes some familiarity with XML. A high level description of the interaction between the different tests and their relationship to the Core Definition Schema is not outlined here.</xsd:documentation>
         <xsd:documentation>The OVAL Schema is maintained by the OVAL Community. For more information, including how to get involved in the project and how to submit change requests, please visit the OVAL website at https://github.com/OVAL-Community/.</xsd:documentation>
         <xsd:documentation>Thanks to Omar Santos and Panos Kampanakis of Cisco for providing this test.</xsd:documentation>
         <xsd:appinfo>
             <schema>IOS-XE Definition</schema>
-            <version>5.12</version>
-            <date>11/29/2024 09:00:00 AM</date>
+            <version>6.0</version>
+            <date>1/1/2025 09:00:00 AM</date>
             <terms_of_use>This software is an open standard developed by multiple parties, including the United States Government (Government). The Government hereby grants you a non-exclusive, royalty-free, worldwide license to use, modify, and/or reproduce the software for any lawful purpose provided that you reproduce this License/Disclaimer language with any use/modification/copy of the software. The Government assumes no responsibility whatsoever for this software's use by other parties, and the software is provided "AS IS" without warranty or guarantee of any kind, express or implied, including, but not limited to, the warranties of merchantability, fitness for a particular purpose, and noninfringement. In no event shall the Government be liable for any claim, damages or other liability, whether in an action of contract, tort or other dealings in the software. The Government has no obligation hereunder to provide maintenance, support, updates, enhancements, or modifications to the software. Users may submit proposals and/or updates regarding the software, which proposals and/or updates the Government, at its sole discretion, can choose to incorporate into the software. Proposals and/or updates submitted to the Government by users must be accompanied by a license to such proposals and/or updates that is no more restrictive than this License/Disclaimer.</terms_of_use>
-            <sch:ns prefix="oval-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5"/>
-            <sch:ns prefix="iosxe-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5#iosxe"/>
+            <sch:ns prefix="oval-def" urn="urn:oval:v6:definitions"/>
+            <sch:ns prefix="iosxe-def" urn="urn:oval:v6:definitions:iosxe"/>
             <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
         </xsd:appinfo>
     </xsd:annotation>
@@ -33,7 +33,7 @@
                     <oval:test>global_test</oval:test>
                     <oval:object>global_object</oval:object>
                     <oval:state>global_state</oval:state>
-                    <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#iosxe">global_item</oval:item>
+                    <oval:item target_namespace="urn:oval:v6:system-characteristics:iosxe">global_item</oval:item>
                 </oval:element_mapping>
             </xsd:appinfo>
             <xsd:appinfo>
@@ -70,7 +70,7 @@
                         <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                         <sch:let name="state_name" value="local-name($reffed_state)"/>
                         <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                        <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#iosxe') and ($state_name='global_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                        <sch:assert test="(($state_namespace='urn:oval:v6:definitions:iosxe') and ($state_name='global_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                     </sch:rule>
                 </sch:pattern>
             </xsd:appinfo>
@@ -124,7 +124,7 @@
                     <oval:test>line_test</oval:test>
                     <oval:object>line_object</oval:object>
                     <oval:state>line_state</oval:state>
-                    <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#iosxe">line_item</oval:item>
+                    <oval:item target_namespace="urn:oval:v6:system-characteristics:iosxe">line_item</oval:item>
                 </oval:element_mapping>
             </xsd:appinfo>
             <xsd:appinfo>
@@ -162,7 +162,7 @@
                         <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                         <sch:let name="state_name" value="local-name($reffed_state)"/>
                         <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                        <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#iosxe') and ($state_name='line_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                        <sch:assert test="(($state_namespace='urn:oval:v6:definitions:iosxe') and ($state_name='line_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                     </sch:rule>
                 </sch:pattern>
             </xsd:appinfo>
@@ -221,7 +221,7 @@
                     <oval:test>version_test</oval:test>
                     <oval:object>version_object</oval:object>
                     <oval:state>version_state</oval:state>
-                    <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#iosxe">version_item</oval:item>
+                    <oval:item target_namespace="urn:oval:v6:system-characteristics:iosxe">version_item</oval:item>
                 </oval:element_mapping>
             </xsd:appinfo>
             <xsd:appinfo>
@@ -385,7 +385,7 @@
                     <oval:test>interface_test</oval:test>
                     <oval:object>interface_object</oval:object>
                     <oval:state>interface_state</oval:state>
-                    <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#iosxe">interface_item</oval:item>
+                    <oval:item target_namespace="urn:oval:v6:system-characteristics:iosxe">interface_item</oval:item>
                 </oval:element_mapping>
             </xsd:appinfo>
             <xsd:appinfo>
@@ -598,7 +598,7 @@
                     <oval:test>section_test</oval:test>
                     <oval:object>section_object</oval:object>
                     <oval:state>section_state</oval:state>
-                    <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#iosxe">section_item</oval:item>
+                    <oval:item target_namespace="urn:oval:v6:system-characteristics:iosxe">section_item</oval:item>
                 </oval:element_mapping>
             </xsd:appinfo>
             <xsd:appinfo>
@@ -636,7 +636,7 @@
                         <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                         <sch:let name="state_name" value="local-name($reffed_state)"/>
                         <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                        <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#iosxe') and ($state_name='section_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type.</sch:assert>
+                        <sch:assert test="(($state_namespace='urn:oval:v6:definitions:iosxe') and ($state_name='section_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type.</sch:assert>
                     </sch:rule>
                 </sch:pattern>
             </xsd:appinfo>
@@ -700,7 +700,7 @@
                     <oval:test>router_test</oval:test>
                     <oval:object>router_object</oval:object>
                     <oval:state>router_state</oval:state>
-                    <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#iosxe">router_item</oval:item>
+                    <oval:item target_namespace="urn:oval:v6:system-characteristics:iosxe">router_item</oval:item>
                 </oval:element_mapping>
             </xsd:appinfo>
 			<xsd:appinfo>
@@ -744,7 +744,7 @@
                         <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                         <sch:let name="state_name" value="local-name($reffed_state)"/>
                         <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                        <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#iosxe') and ($state_name='router_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type.</sch:assert>
+                        <sch:assert test="(($state_namespace='urn:oval:v6:definitions:iosxe') and ($state_name='router_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type.</sch:assert>
                     </sch:rule>
                 </sch:pattern>
             </xsd:appinfo>
@@ -842,7 +842,7 @@
                     <oval:test>bgpneighbor_test</oval:test>
                     <oval:object>bgpneighbor_object</oval:object>
                     <oval:state>bgpneighbor_state</oval:state>
-                    <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#iosxe">bgpneighbor_item</oval:item>
+                    <oval:item target_namespace="urn:oval:v6:system-characteristics:iosxe">bgpneighbor_item</oval:item>
                 </oval:element_mapping>
             </xsd:appinfo>
             <xsd:appinfo>
@@ -880,7 +880,7 @@
                         <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                         <sch:let name="state_name" value="local-name($reffed_state)"/>
                         <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                        <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#iosxe') and ($state_name='bgpneighbor_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type.</sch:assert>
+                        <sch:assert test="(($state_namespace='urn:oval:v6:definitions:iosxe') and ($state_name='bgpneighbor_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type.</sch:assert>
                     </sch:rule>
                 </sch:pattern>
             </xsd:appinfo>
@@ -939,7 +939,7 @@
                     <oval:test>routingprotocolauthintf_test</oval:test>
                     <oval:object>routingprotocolauthintf_object</oval:object>
                     <oval:state>routingprotocolauthintf_state</oval:state>
-                    <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#iosxe">routingprotocolauthintf_item</oval:item>
+                    <oval:item target_namespace="urn:oval:v6:system-characteristics:iosxe">routingprotocolauthintf_item</oval:item>
                 </oval:element_mapping>
             </xsd:appinfo>
             <xsd:appinfo>
@@ -977,7 +977,7 @@
                         <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                         <sch:let name="state_name" value="local-name($reffed_state)"/>
                         <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                        <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#iosxe') and ($state_name='routingprotocolauthintf_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type.</sch:assert>
+                        <sch:assert test="(($state_namespace='urn:oval:v6:definitions:iosxe') and ($state_name='routingprotocolauthintf_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type.</sch:assert>
                     </sch:rule>
                 </sch:pattern>
             </xsd:appinfo>
@@ -1075,7 +1075,7 @@
                     <oval:test>acl_test</oval:test>
                     <oval:object>acl_object</oval:object>
                     <oval:state>acl_state</oval:state>
-                    <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#iosxe">acl_item</oval:item>
+                    <oval:item target_namespace="urn:oval:v6:system-characteristics:iosxe">acl_item</oval:item>
                 </oval:element_mapping>
             </xsd:appinfo>
 					<xsd:appinfo>
@@ -1119,7 +1119,7 @@
                         <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                         <sch:let name="state_name" value="local-name($reffed_state)"/>
                         <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                        <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#iosxe') and ($state_name='acl_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type.</sch:assert>
+                        <sch:assert test="(($state_namespace='urn:oval:v6:definitions:iosxe') and ($state_name='acl_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type.</sch:assert>
                     </sch:rule>
                 </sch:pattern>
             </xsd:appinfo>
@@ -1208,7 +1208,7 @@
                     <oval:test>snmphost_test</oval:test>
                     <oval:object>snmphost_object</oval:object>
                     <oval:state>snmphost_state</oval:state>
-                    <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#iosxe">snmphost_item</oval:item>
+                    <oval:item target_namespace="urn:oval:v6:system-characteristics:iosxe">snmphost_item</oval:item>
                 </oval:element_mapping>
             </xsd:appinfo>
             <xsd:appinfo>
@@ -1246,7 +1246,7 @@
                         <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                         <sch:let name="state_name" value="local-name($reffed_state)"/>
                         <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                        <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#iosxe') and ($state_name='snmphost_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type.</sch:assert>
+                        <sch:assert test="(($state_namespace='urn:oval:v6:definitions:iosxe') and ($state_name='snmphost_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type.</sch:assert>
                     </sch:rule>
                 </sch:pattern>
             </xsd:appinfo>
@@ -1320,7 +1320,7 @@
                     <oval:test>snmpcommunity_test</oval:test>
                     <oval:object>snmpcommunity_object</oval:object>
                     <oval:state>snmpcommunity_state</oval:state>
-                    <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#iosxe">snmpcommunity_item</oval:item>
+                    <oval:item target_namespace="urn:oval:v6:system-characteristics:iosxe">snmpcommunity_item</oval:item>
                 </oval:element_mapping>
             </xsd:appinfo>
             <xsd:appinfo>
@@ -1358,7 +1358,7 @@
                         <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                         <sch:let name="state_name" value="local-name($reffed_state)"/>
                         <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                        <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#iosxe') and ($state_name='snmpcommunity_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type.</sch:assert>
+                        <sch:assert test="(($state_namespace='urn:oval:v6:definitions:iosxe') and ($state_name='snmpcommunity_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type.</sch:assert>
                     </sch:rule>
                 </sch:pattern>
             </xsd:appinfo>
@@ -1432,7 +1432,7 @@
                     <oval:test>snmpuser_test</oval:test>
                     <oval:object>snmpuser_object</oval:object>
                     <oval:state>snmpuser_state</oval:state>
-                    <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#iosxe">snmpuser_item</oval:item>
+                    <oval:item target_namespace="urn:oval:v6:system-characteristics:iosxe">snmpuser_item</oval:item>
                 </oval:element_mapping>
             </xsd:appinfo>
             <xsd:appinfo>
@@ -1470,7 +1470,7 @@
                         <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                         <sch:let name="state_name" value="local-name($reffed_state)"/>
                         <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                        <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#iosxe') and ($state_name='snmpuser_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type.</sch:assert>
+                        <sch:assert test="(($state_namespace='urn:oval:v6:definitions:iosxe') and ($state_name='snmpuser_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type.</sch:assert>
                     </sch:rule>
                 </sch:pattern>
             </xsd:appinfo>
@@ -1554,7 +1554,7 @@
                     <oval:test>snmpgroup_test</oval:test>
                     <oval:object>snmpgroup_object</oval:object>
                     <oval:state>snmpgroup_state</oval:state>
-                    <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#iosxe">snmpgroup_item</oval:item>
+                    <oval:item target_namespace="urn:oval:v6:system-characteristics:iosxe">snmpgroup_item</oval:item>
                 </oval:element_mapping>
             </xsd:appinfo>
             <xsd:appinfo>
@@ -1592,7 +1592,7 @@
                         <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                         <sch:let name="state_name" value="local-name($reffed_state)"/>
                         <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                        <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#iosxe') and ($state_name='snmpgroup_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type.</sch:assert>
+                        <sch:assert test="(($state_namespace='urn:oval:v6:definitions:iosxe') and ($state_name='snmpgroup_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type.</sch:assert>
                     </sch:rule>
                 </sch:pattern>
             </xsd:appinfo>
@@ -1681,7 +1681,7 @@
                     <oval:test>snmpview_test</oval:test>
                     <oval:object>snmpview_object</oval:object>
                     <oval:state>snmpview_state</oval:state>
-                    <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#iosxe">snmpview_item</oval:item>
+                    <oval:item target_namespace="urn:oval:v6:system-characteristics:iosxe">snmpview_item</oval:item>
                 </oval:element_mapping>
             </xsd:appinfo>
 			<xsd:appinfo>
@@ -1725,7 +1725,7 @@
                         <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                         <sch:let name="state_name" value="local-name($reffed_state)"/>
                         <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                        <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#iosxe') and ($state_name='snmpview_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type.</sch:assert>
+                        <sch:assert test="(($state_namespace='urn:oval:v6:definitions:iosxe') and ($state_name='snmpview_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type.</sch:assert>
                     </sch:rule>
                 </sch:pattern>
             </xsd:appinfo>

--- a/oval-schemas/iosxe-system-characteristics-schema.xsd
+++ b/oval-schemas/iosxe-system-characteristics-schema.xsd
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-            xmlns:oval-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5"
-            xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5"
-            xmlns:iosxe-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#iosxe"
+            xmlns:oval-sc="urn:oval:v6:system-characteristics"
+            xmlns:oval="urn:oval:v6:common"
+            xmlns:iosxe-sc="urn:oval:v6:system-characteristics:iosxe"
             xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-            targetNamespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#iosxe"
-            elementFormDefault="qualified" version="5.12">
-    <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5" schemaLocation="oval-system-characteristics-schema.xsd"/>
-    <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-common-5" schemaLocation="oval-common-schema.xsd"/>
+            targetNamespace="urn:oval:v6:system-characteristics:iosxe"
+            elementFormDefault="qualified" version="6.0">
+    <xsd:import namespace="urn:oval:v6:system-characteristics" schemaLocation="oval-system-characteristics-schema.xsd"/>
+    <xsd:import namespace="urn:oval:v6:common" schemaLocation="oval-common-schema.xsd"/>
     <xsd:annotation>
         <xsd:documentation>The following is a description of the elements, types, and attributes that compose the IOS-XE specific system characteristic items found in Open Vulnerability and Assessment Language (OVAL). Each item is an extension of the standard item element defined in the Core System Characteristic Schema. Through extension, each item inherits a set of elements and attributes that are shared amongst all OVAL Items. Each item is described in detail and should provide the information necessary to understand what each element and attribute represents. This document is intended for developers and assumes some familiarity with XML. A high level description of the interaction between the different tests and their relationship to the Core System Characteristic Schema is not outlined here.</xsd:documentation>
         <xsd:documentation>The OVAL Schema is maintained by the OVAL Community. For more information, including how to get involved in the project and how to submit change requests, please visit the OVAL website at https://github.com/OVAL-Community/.</xsd:documentation>
         <xsd:documentation>Thanks to Omar Santos and Panos Kampanakis of Cisco for providing this test.</xsd:documentation>
         <xsd:appinfo>
             <schema>IOS-XE System Characteristics</schema>
-            <version>5.12</version>
-            <date>11/29/2024 09:00:00 AM</date>
+            <version>6.0</version>
+            <date>1/1/2025 09:00:00 AM</date>
             <terms_of_use>This software is an open standard developed by multiple parties, including the United States Government (Government). The Government hereby grants you a non-exclusive, royalty-free, worldwide license to use, modify, and/or reproduce the software for any lawful purpose provided that you reproduce this License/Disclaimer language with any use/modification/copy of the software. The Government assumes no responsibility whatsoever for this software's use by other parties, and the software is provided "AS IS" without warranty or guarantee of any kind, express or implied, including, but not limited to, the warranties of merchantability, fitness for a particular purpose, and noninfringement. In no event shall the Government be liable for any claim, damages or other liability, whether in an action of contract, tort or other dealings in the software. The Government has no obligation hereunder to provide maintenance, support, updates, enhancements, or modifications to the software. Users may submit proposals and/or updates regarding the software, which proposals and/or updates the Government, at its sole discretion, can choose to incorporate into the software. Proposals and/or updates submitted to the Government by users must be accompanied by a license to such proposals and/or updates that is no more restrictive than this License/Disclaimer.</terms_of_use>
-            <sch:ns prefix="oval-sc" uri="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5"/>
-            <sch:ns prefix="iosxe-sc" uri="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#iosxe"/>
+            <sch:ns prefix="oval-sc" urn="urn:oval:v6:system-characteristics"/>
+            <sch:ns prefix="iosxe-sc" urn="urn:oval:v6:system-characteristics:iosxe"/>
             <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
         </xsd:appinfo>
     </xsd:annotation>

--- a/oval-schemas/junos-definitions-schema.xsd
+++ b/oval-schemas/junos-definitions-schema.xsd
@@ -1,22 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-            xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5"
-            xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5"
-            xmlns:junos-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#junos"
+            xmlns:oval="urn:oval:v6:common"
+            xmlns:oval-def="urn:oval:v6:definitions"
+            xmlns:junos-def="urn:oval:v6:definitions:junos"
             xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-            targetNamespace="http://oval.mitre.org/XMLSchema/oval-definitions-5#junos"
-            elementFormDefault="qualified" version="5.12">
-    <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-definitions-5" schemaLocation="oval-definitions-schema.xsd"/>
+            targetNamespace="urn:oval:v6:definitions:junos"
+            elementFormDefault="qualified" version="6.0">
+    <xsd:import namespace="urn:oval:v6:definitions" schemaLocation="oval-definitions-schema.xsd"/>
     <xsd:annotation>
         <xsd:documentation>The following is a description of the elements, types, and attributes that compose the Junos-specific tests found in Open Vulnerability and Assessment Language (OVAL). Each test is an extension of the standard test element defined in the Core Definition Schema. Through extension, each test inherits a set of elements and attributes that are shared amongst all OVAL tests. Each test is described in detail and should provide the information necessary to understand what each element and attribute represents. This document is intended for developers and assumes some familiarity with XML. A high level description of the interaction between the different tests and their relationship to the Core Definition Schema is not outlined here.</xsd:documentation>
         <xsd:documentation>This schema was originally developed by David Solin at jOVAL.org. The OVAL Schema is maintained by the OVAL Community. For more information, including how to get involved in the project and how to submit change requests, please visit the OVAL website at https://github.com/OVAL-Community/.</xsd:documentation>
         <xsd:appinfo>
             <schema>Junos Definition</schema>
-            <version>5.12</version>
-            <date>11/29/2024 09:00:00 AM</date>
+            <version>6.0</version>
+            <date>1/1/2025 09:00:00 AM</date>
             <terms_of_use>This software is an open standard developed by multiple parties, including the United States Government (Government). The Government hereby grants you a non-exclusive, royalty-free, worldwide license to use, modify, and/or reproduce the software for any lawful purpose provided that you reproduce this License/Disclaimer language with any use/modification/copy of the software. The Government assumes no responsibility whatsoever for this software's use by other parties, and the software is provided "AS IS" without warranty or guarantee of any kind, express or implied, including, but not limited to, the warranties of merchantability, fitness for a particular purpose, and noninfringement. In no event shall the Government be liable for any claim, damages or other liability, whether in an action of contract, tort or other dealings in the software. The Government has no obligation hereunder to provide maintenance, support, updates, enhancements, or modifications to the software. Users may submit proposals and/or updates regarding the software, which proposals and/or updates the Government, at its sole discretion, can choose to incorporate into the software. Proposals and/or updates submitted to the Government by users must be accompanied by a license to such proposals and/or updates that is no more restrictive than this License/Disclaimer.</terms_of_use>
-            <sch:ns prefix="oval-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5"/>
-            <sch:ns prefix="junos-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5#junos"/>
+            <sch:ns prefix="oval-def" urn="urn:oval:v6:definitions"/>
+            <sch:ns prefix="junos-def" urn="urn:oval:v6:definitions:junos"/>
             <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
         </xsd:appinfo>
     </xsd:annotation>
@@ -32,7 +32,7 @@
                         <oval:test>xml_config_test</oval:test>
                         <oval:object>xml_config_object</oval:object>
                         <oval:state>xml_config_state</oval:state>
-                        <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#junos">xml_config_item</oval:item>
+                        <oval:item target_namespace="urn:oval:v6:system-characteristics:junos">xml_config_item</oval:item>
                     </oval:element_mapping>
                 </xsd:appinfo>
 				<xsd:appinfo>
@@ -74,7 +74,7 @@
                         <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                         <sch:let name="state_name" value="local-name($reffed_state)"/>
                         <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                        <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#junos') and ($state_name='config_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                        <sch:assert test="(($state_namespace='urn:oval:v6:definitions:junos') and ($state_name='config_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                     </sch:rule>
                 </sch:pattern>
             </xsd:appinfo>
@@ -140,7 +140,7 @@
                     <oval:test>show_test</oval:test>
                     <oval:object>show_object</oval:object>
                     <oval:state>show_state</oval:state>
-                    <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#junos">show_item</oval:item>
+                    <oval:item target_namespace="urn:oval:v6:system-characteristics:junos">show_item</oval:item>
                 </oval:element_mapping>
             </xsd:appinfo>
         </xsd:annotation>
@@ -167,7 +167,7 @@
                         <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                         <sch:let name="state_name" value="local-name($reffed_state)"/>
                         <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                        <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#junos') and ($state_name='show_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                        <sch:assert test="(($state_namespace='urn:oval:v6:definitions:junos') and ($state_name='show_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                     </sch:rule>
                 </sch:pattern>
             </xsd:appinfo>
@@ -226,7 +226,7 @@
                     <oval:test>version_test</oval:test>
                     <oval:object>version_object</oval:object>
                     <oval:state>version_state</oval:state>
-                    <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#junos">version_item</oval:item>
+                    <oval:item target_namespace="urn:oval:v6:system-characteristics:junos">version_item</oval:item>
                 </oval:element_mapping>
             </xsd:appinfo>
 			<xsd:appinfo>
@@ -259,7 +259,7 @@
                         <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                         <sch:let name="state_name" value="local-name($reffed_state)"/>
                         <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                        <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#junos') and ($state_name='version_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                        <sch:assert test="(($state_namespace='urn:oval:v6:definitions:junos') and ($state_name='version_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                     </sch:rule>
                 </sch:pattern>
             </xsd:appinfo>
@@ -353,7 +353,7 @@
                     <oval:test>xml_show_test</oval:test>
                     <oval:object>xml_show_object</oval:object>
                     <oval:state>xml_show_state</oval:state>
-                    <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#junos">xml_show_item</oval:item>
+                    <oval:item target_namespace="urn:oval:v6:system-characteristics:junos">xml_show_item</oval:item>
                 </oval:element_mapping>
             </xsd:appinfo>
 			<xsd:appinfo>
@@ -386,7 +386,7 @@
                         <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                         <sch:let name="state_name" value="local-name($reffed_state)"/>
                         <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                        <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#junos') and ($state_name='xml_show_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                        <sch:assert test="(($state_namespace='urn:oval:v6:definitions:junos') and ($state_name='xml_show_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                     </sch:rule>
                 </sch:pattern>
             </xsd:appinfo>

--- a/oval-schemas/junos-system-characteristics-schema.xsd
+++ b/oval-schemas/junos-system-characteristics-schema.xsd
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-            xmlns:oval-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5"
-            xmlns:junos-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#junos"
+            xmlns:oval-sc="urn:oval:v6:system-characteristics"
+            xmlns:junos-sc="urn:oval:v6:system-characteristics:junos"
             xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-            targetNamespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#junos"
-            elementFormDefault="qualified" version="5.12">
-    <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5" schemaLocation="oval-system-characteristics-schema.xsd"/>
+            targetNamespace="urn:oval:v6:system-characteristics:junos"
+            elementFormDefault="qualified" version="6.0">
+    <xsd:import namespace="urn:oval:v6:system-characteristics" schemaLocation="oval-system-characteristics-schema.xsd"/>
     <xsd:annotation>
         <xsd:documentation>The following is a description of the elements, types, and attributes that compose the Junos-specific system characteristic items found in Open Vulnerability and Assessment Language (OVAL). Each item is an extension of the standard item element defined in the Core System Characteristic Schema. Through extension, each item inherits a set of elements and attributes that are shared amongst all OVAL Items. Each item is described in detail and should provide the information necessary to understand what each element and attribute represents. This document is intended for developers and assumes some familiarity with XML. A high level description of the interaction between the different tests and their relationship to the Core System Characteristic Schema is not outlined here.</xsd:documentation>
         <xsd:documentation>This schema was originally developed by David Solin at jOVAL.org. The OVAL Schema is maintained by the OVAL Community. For more information, including how to get involved in the project and how to submit change requests, please visit the OVAL website at https://github.com/OVAL-Community/.</xsd:documentation>
         <xsd:appinfo>
             <schema>Junos System Characteristics</schema>
-            <version>5.12</version>
-            <date>11/29/2024 09:00:00 AM</date>
+            <version>6.0</version>
+            <date>1/1/2025 09:00:00 AM</date>
             <terms_of_use>This software is an open standard developed by multiple parties, including the United States Government (Government). The Government hereby grants you a non-exclusive, royalty-free, worldwide license to use, modify, and/or reproduce the software for any lawful purpose provided that you reproduce this License/Disclaimer language with any use/modification/copy of the software. The Government assumes no responsibility whatsoever for this software's use by other parties, and the software is provided "AS IS" without warranty or guarantee of any kind, express or implied, including, but not limited to, the warranties of merchantability, fitness for a particular purpose, and noninfringement. In no event shall the Government be liable for any claim, damages or other liability, whether in an action of contract, tort or other dealings in the software. The Government has no obligation hereunder to provide maintenance, support, updates, enhancements, or modifications to the software. Users may submit proposals and/or updates regarding the software, which proposals and/or updates the Government, at its sole discretion, can choose to incorporate into the software. Proposals and/or updates submitted to the Government by users must be accompanied by a license to such proposals and/or updates that is no more restrictive than this License/Disclaimer.</terms_of_use>
-            <sch:ns prefix="oval-sc" uri="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5"/>
-            <sch:ns prefix="junos-sc" uri="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#junos"/>
+            <sch:ns prefix="oval-sc" urn="urn:oval:v6:system-characteristics"/>
+            <sch:ns prefix="junos-sc" urn="urn:oval:v6:system-characteristics:junos"/>
             <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
         </xsd:appinfo>
     </xsd:annotation>

--- a/oval-schemas/linux-definitions-schema.xsd
+++ b/oval-schemas/linux-definitions-schema.xsd
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-            xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5"
-            xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5"
-            xmlns:linux-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux"
+            xmlns:oval="urn:oval:v6:common"
+            xmlns:oval-def="urn:oval:v6:definitions"
+            xmlns:linux-def="urn:oval:v6:definitions:linux"
             xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-            targetNamespace="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux"
-            elementFormDefault="qualified" version="5.12">
-     <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-definitions-5" schemaLocation="oval-definitions-schema.xsd"/>
-     <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-common-5" schemaLocation="oval-common-schema.xsd"/>
+            targetNamespace="urn:oval:v6:definitions:linux"
+            elementFormDefault="qualified" version="6.0">
+     <xsd:import namespace="urn:oval:v6:definitions" schemaLocation="oval-definitions-schema.xsd"/>
+     <xsd:import namespace="urn:oval:v6:common" schemaLocation="oval-common-schema.xsd"/>
      <xsd:annotation>
           <xsd:documentation>The following is a description of the elements, types, and attributes that compose the Linux specific tests found in Open Vulnerability and Assessment Language (OVAL). Each test is an extension of the standard test element defined in the Core Definition Schema. Through extension, each test inherits a set of elements and attributes that are shared amongst all OVAL tests. Each test is described in detail and should provide the information necessary to understand what each element and attribute represents. This document is intended for developers and assumes some familiarity with XML. A high level description of the interaction between the different tests and their relationship to the Core Definition Schema is not outlined here.</xsd:documentation>
           <xsd:documentation>The OVAL Schema is maintained by the OVAL Community. For more information, including how to get involved in the project and how to submit change requests, please visit the OVAL website at https://github.com/OVAL-Community/.</xsd:documentation>
           <xsd:appinfo>
                <schema>Linux Definition</schema>
-               <version>5.12</version>
-               <date>11/29/2024 09:00:00 AM</date>
+               <version>6.0</version>
+               <date>1/1/2025 09:00:00 AM</date>
                 <terms_of_use>This software is an open standard developed by multiple parties, including the United States Government (Government). The Government hereby grants you a non-exclusive, royalty-free, worldwide license to use, modify, and/or reproduce the software for any lawful purpose provided that you reproduce this License/Disclaimer language with any use/modification/copy of the software. The Government assumes no responsibility whatsoever for this software's use by other parties, and the software is provided "AS IS" without warranty or guarantee of any kind, express or implied, including, but not limited to, the warranties of merchantability, fitness for a particular purpose, and noninfringement. In no event shall the Government be liable for any claim, damages or other liability, whether in an action of contract, tort or other dealings in the software. The Government has no obligation hereunder to provide maintenance, support, updates, enhancements, or modifications to the software. Users may submit proposals and/or updates regarding the software, which proposals and/or updates the Government, at its sole discretion, can choose to incorporate into the software. Proposals and/or updates submitted to the Government by users must be accompanied by a license to such proposals and/or updates that is no more restrictive than this License/Disclaimer.</terms_of_use>
-               <sch:ns prefix="oval-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5"/>
-               <sch:ns prefix="linux-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux"/>
+               <sch:ns prefix="oval-def" urn="urn:oval:v6:definitions"/>
+               <sch:ns prefix="linux-def" urn="urn:oval:v6:definitions:linux"/>
                <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
           </xsd:appinfo>
      </xsd:annotation>
@@ -126,7 +126,7 @@
                          <oval:test>dpkginfo_test</oval:test>
                          <oval:object>dpkginfo_object</oval:object>
                          <oval:state>dpkginfo_state</oval:state>
-                         <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#linux">dpkginfo_item</oval:item>
+                         <oval:item target_namespace="urn:oval:v6:system-characteristics:linux">dpkginfo_item</oval:item>
                     </oval:element_mapping>
                </xsd:appinfo>
                <xsd:appinfo>
@@ -164,7 +164,7 @@
                               <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                               <sch:let name="state_name" value="local-name($reffed_state)"/>
                               <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                              <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#linux') and ($state_name='dpkginfo_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                              <sch:assert test="(($state_namespace='urn:oval:v6:definitions:linux') and ($state_name='dpkginfo_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                          </sch:rule>
                     </sch:pattern>
                </xsd:appinfo>
@@ -306,7 +306,7 @@
                          <oval:test>iflisteners_test</oval:test>
                          <oval:object>iflisteners_object</oval:object>
                          <oval:state>iflisteners_state</oval:state>
-                         <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#linux">iflisteners_item</oval:item>
+                         <oval:item target_namespace="urn:oval:v6:system-characteristics:linux">iflisteners_item</oval:item>
                     </oval:element_mapping>
                </xsd:appinfo>
 				<xsd:appinfo>
@@ -349,7 +349,7 @@
                               <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                               <sch:let name="state_name" value="local-name($reffed_state)"/>
                               <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                              <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#linux') and ($state_name='iflisteners_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                              <sch:assert test="(($state_namespace='urn:oval:v6:definitions:linux') and ($state_name='iflisteners_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                          </sch:rule>
                     </sch:pattern>
                </xsd:appinfo>
@@ -428,7 +428,7 @@
                          <oval:test>inetlisteningservers_test</oval:test>
                          <oval:object>inetlisteningservers_object</oval:object>
                          <oval:state>inetlisteningservers_state</oval:state>
-                         <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#linux">inetlisteningserver_item</oval:item>
+                         <oval:item target_namespace="urn:oval:v6:system-characteristics:linux">inetlisteningserver_item</oval:item>
                     </oval:element_mapping>
                </xsd:appinfo>
                <xsd:appinfo>
@@ -466,7 +466,7 @@
                               <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                               <sch:let name="state_name" value="local-name($reffed_state)"/>
                               <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                              <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#linux') and ($state_name='inetlisteningservers_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                              <sch:assert test="(($state_namespace='urn:oval:v6:definitions:linux') and ($state_name='inetlisteningservers_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                          </sch:rule>
                     </sch:pattern>
                </xsd:appinfo>
@@ -579,7 +579,7 @@
                          <oval:test>kernelmodule_test</oval:test>
                          <oval:object>kernelmodule_object</oval:object>
                          <oval:state>kernelmodule_state</oval:state>
-                         <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#linux">kernelmodule_item</oval:item>
+                         <oval:item target_namespace="urn:oval:v6:system-characteristics:linux">kernelmodule_item</oval:item>
                     </oval:element_mapping>
                </xsd:appinfo>
                <xsd:appinfo>
@@ -635,7 +635,7 @@
                               <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                               <sch:let name="state_name" value="local-name($reffed_state)"/>
                               <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                              <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#linux') and ($state_name='kernelmodule_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                              <sch:assert test="(($state_namespace='urn:oval:v6:definitions:linux') and ($state_name='kernelmodule_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                          </sch:rule>
                     </sch:pattern>
                </xsd:appinfo>
@@ -702,7 +702,7 @@
                          <oval:test>partition_test</oval:test>
                          <oval:object>partition_object</oval:object>
                          <oval:state>partition_state</oval:state>
-                         <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#linux">partition_item</oval:item>
+                         <oval:item target_namespace="urn:oval:v6:system-characteristics:linux">partition_item</oval:item>
                     </oval:element_mapping>
                </xsd:appinfo>
                <xsd:appinfo>
@@ -739,7 +739,7 @@
                               <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                               <sch:let name="state_name" value="local-name($reffed_state)"/>
                               <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                              <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#linux') and ($state_name='partition_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                              <sch:assert test="(($state_namespace='urn:oval:v6:definitions:linux') and ($state_name='partition_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                          </sch:rule>
                     </sch:pattern>
                </xsd:appinfo>
@@ -839,7 +839,7 @@
                          <oval:test>rpminfo_test</oval:test>
                          <oval:object>rpminfo_object</oval:object>
                          <oval:state>rpminfo_state</oval:state>
-                         <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#linux">rpminfo_item</oval:item>
+                         <oval:item target_namespace="urn:oval:v6:system-characteristics:linux">rpminfo_item</oval:item>
                     </oval:element_mapping>
                </xsd:appinfo>
                <xsd:appinfo>
@@ -877,7 +877,7 @@
                               <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                               <sch:let name="state_name" value="local-name($reffed_state)"/>
                               <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                              <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#linux') and ($state_name='rpminfo_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                              <sch:assert test="(($state_namespace='urn:oval:v6:definitions:linux') and ($state_name='rpminfo_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                          </sch:rule>
                     </sch:pattern>
                </xsd:appinfo>
@@ -1024,7 +1024,7 @@
                          <oval:test>rpmverify_test</oval:test>
                          <oval:object>rpmverify_object</oval:object>
                          <oval:state>rpmverify_state</oval:state>
-                         <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#linux">rpmverify_item</oval:item>
+                         <oval:item target_namespace="urn:oval:v6:system-characteristics:linux">rpmverify_item</oval:item>
                     </oval:element_mapping>
                </xsd:appinfo>
 				<xsd:appinfo>
@@ -1079,7 +1079,7 @@
                               <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                               <sch:let name="state_name" value="local-name($reffed_state)"/>
                               <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                              <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#linux') and ($state_name='rpmverify_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                              <sch:assert test="(($state_namespace='urn:oval:v6:definitions:linux') and ($state_name='rpmverify_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                          </sch:rule>
                     </sch:pattern>
                </xsd:appinfo>
@@ -1325,7 +1325,7 @@
                          <oval:test>rpmverifyfile_test</oval:test>
                          <oval:object>rpmverifyfile_object</oval:object>
                          <oval:state>rpmverifyfile_state</oval:state>
-                         <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#linux">rpmverifyfile_item</oval:item>
+                         <oval:item target_namespace="urn:oval:v6:system-characteristics:linux">rpmverifyfile_item</oval:item>
                     </oval:element_mapping>
                </xsd:appinfo>
                <xsd:appinfo>
@@ -1362,7 +1362,7 @@
                               <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                               <sch:let name="state_name" value="local-name($reffed_state)"/>
                               <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                              <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#linux') and ($state_name='rpmverifyfile_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                              <sch:assert test="(($state_namespace='urn:oval:v6:definitions:linux') and ($state_name='rpmverifyfile_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                          </sch:rule>
                     </sch:pattern>
                </xsd:appinfo>
@@ -1710,7 +1710,7 @@
                          <oval:test>rpmverifypackage_test</oval:test>
                          <oval:object>rpmverifypackage_object</oval:object>
                          <oval:state>rpmverifypackage_state</oval:state>
-                         <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#linux">rpmverifypackage_item</oval:item>
+                         <oval:item target_namespace="urn:oval:v6:system-characteristics:linux">rpmverifypackage_item</oval:item>
                     </oval:element_mapping>
                </xsd:appinfo>
                <xsd:appinfo>
@@ -1747,7 +1747,7 @@
                               <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                               <sch:let name="state_name" value="local-name($reffed_state)"/>
                               <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                              <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#linux') and ($state_name='rpmverifypackage_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                              <sch:assert test="(($state_namespace='urn:oval:v6:definitions:linux') and ($state_name='rpmverifypackage_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                          </sch:rule>
                     </sch:pattern>
                </xsd:appinfo>
@@ -2024,7 +2024,7 @@
                          <oval:test>selinuxboolean_test</oval:test>
                          <oval:object>selinuxboolean_object</oval:object>
                          <oval:state>selinuxboolean_state</oval:state>
-                         <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#linux">selinuxboolean_item</oval:item>
+                         <oval:item target_namespace="urn:oval:v6:system-characteristics:linux">selinuxboolean_item</oval:item>
                     </oval:element_mapping>
                </xsd:appinfo>
                <xsd:appinfo>
@@ -2061,7 +2061,7 @@
                               <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                               <sch:let name="state_name" value="local-name($reffed_state)"/>
                               <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                              <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#linux') and ($state_name='selinuxboolean_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                              <sch:assert test="(($state_namespace='urn:oval:v6:definitions:linux') and ($state_name='selinuxboolean_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                          </sch:rule>
                     </sch:pattern>
                </xsd:appinfo>
@@ -2125,7 +2125,7 @@
                          <oval:test>selinuxsecuritycontext_test</oval:test>
                          <oval:object>selinuxsecuritycontext_object</oval:object>
                          <oval:state>selinuxsecuritycontext_state</oval:state>
-                         <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#linux">selinuxsecuritycontext_item</oval:item>
+                         <oval:item target_namespace="urn:oval:v6:system-characteristics:linux">selinuxsecuritycontext_item</oval:item>
                     </oval:element_mapping>
                </xsd:appinfo>
                <xsd:appinfo>
@@ -2162,7 +2162,7 @@
                               <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                               <sch:let name="state_name" value="local-name($reffed_state)"/>
                               <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                              <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#linux') and ($state_name='selinuxsecuritycontext_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                              <sch:assert test="(($state_namespace='urn:oval:v6:definitions:linux') and ($state_name='selinuxsecuritycontext_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                          </sch:rule>
                     </sch:pattern>
                </xsd:appinfo>
@@ -2419,7 +2419,7 @@
                          <oval:test>slackwarepkginfo_test</oval:test>
                          <oval:object>slackwarepkginfo_object</oval:object>
                          <oval:state>slackwarepkginfo_state</oval:state>
-                         <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#linux">slackwarepkginfo_item</oval:item>
+                         <oval:item target_namespace="urn:oval:v6:system-characteristics:linux">slackwarepkginfo_item</oval:item>
                     </oval:element_mapping>
                </xsd:appinfo>
 				<xsd:appinfo>
@@ -2463,7 +2463,7 @@
                               <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                               <sch:let name="state_name" value="local-name($reffed_state)"/>
                               <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                              <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#linux') and ($state_name='slackwarepkginfo_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                              <sch:assert test="(($state_namespace='urn:oval:v6:definitions:linux') and ($state_name='slackwarepkginfo_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                          </sch:rule>
                     </sch:pattern>
                </xsd:appinfo>
@@ -2546,7 +2546,7 @@
                          <oval:test>systemdunitdependency_test</oval:test>
                          <oval:object>systemdunitdependency_object</oval:object>
                          <oval:state>systemdunitdependency_state</oval:state>
-                         <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#linux">systemdunitdependency_item</oval:item>
+                         <oval:item target_namespace="urn:oval:v6:system-characteristics:linux">systemdunitdependency_item</oval:item>
                     </oval:element_mapping>
                </xsd:appinfo>
                <xsd:appinfo>
@@ -2583,7 +2583,7 @@
                               <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                               <sch:let name="state_name" value="local-name($reffed_state)"/>
                               <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                              <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#linux') and ($state_name='systemdunitdependency_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                              <sch:assert test="(($state_namespace='urn:oval:v6:definitions:linux') and ($state_name='systemdunitdependency_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                          </sch:rule>
                     </sch:pattern>
                </xsd:appinfo>
@@ -2679,7 +2679,7 @@
                               <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                               <sch:let name="state_name" value="local-name($reffed_state)"/>
                               <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                              <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#linux') and ($state_name='systemdunitproperty_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                              <sch:assert test="(($state_namespace='urn:oval:v6:definitions:linux') and ($state_name='systemdunitproperty_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                          </sch:rule>
                     </sch:pattern>
                </xsd:appinfo>

--- a/oval-schemas/linux-system-characteristics-schema.xsd
+++ b/oval-schemas/linux-system-characteristics-schema.xsd
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-            xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5"
-            xmlns:oval-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5"
-            xmlns:linux-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#linux"
+            xmlns:oval="urn:oval:v6:common"
+            xmlns:oval-sc="urn:oval:v6:system-characteristics"
+            xmlns:linux-sc="urn:oval:v6:system-characteristics:linux"
             xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-            targetNamespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#linux"
-            elementFormDefault="qualified" version="5.12">
-     <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5" schemaLocation="oval-system-characteristics-schema.xsd"/>
-     <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-common-5" schemaLocation="oval-common-schema.xsd"/>
+            targetNamespace="urn:oval:v6:system-characteristics:linux"
+            elementFormDefault="qualified" version="6.0">
+     <xsd:import namespace="urn:oval:v6:system-characteristics" schemaLocation="oval-system-characteristics-schema.xsd"/>
+     <xsd:import namespace="urn:oval:v6:common" schemaLocation="oval-common-schema.xsd"/>
      <xsd:annotation>
           <xsd:documentation>The following is a description of the elements, types, and attributes that compose the Linux specific system characteristic items found in Open Vulnerability and Assessment Language (OVAL). Each item is an extension of the standard item element defined in the Core System Characteristic Schema. Through extension, each item inherits a set of elements and attributes that are shared amongst all OVAL Items. Each item is described in detail and should provide the information necessary to understand what each element and attribute represents. This document is intended for developers and assumes some familiarity with XML. A high level description of the interaction between the different tests and their relationship to the Core System Characteristic Schema is not outlined here.</xsd:documentation>
           <xsd:documentation>The OVAL Schema is maintained by the OVAL Community. For more information, including how to get involved in the project and how to submit change requests, please visit the OVAL website at https://github.com/OVAL-Community/.</xsd:documentation>
           <xsd:appinfo>
                <schema>Linux System Characteristics</schema>
-               <version>5.12</version>
-               <date>11/29/2024 09:00:00 AM</date>
+               <version>6.0</version>
+               <date>1/1/2025 09:00:00 AM</date>
                <terms_of_use>This software is an open standard developed by multiple parties, including the United States Government (Government). The Government hereby grants you a non-exclusive, royalty-free, worldwide license to use, modify, and/or reproduce the software for any lawful purpose provided that you reproduce this License/Disclaimer language with any use/modification/copy of the software. The Government assumes no responsibility whatsoever for this software's use by other parties, and the software is provided "AS IS" without warranty or guarantee of any kind, express or implied, including, but not limited to, the warranties of merchantability, fitness for a particular purpose, and noninfringement. In no event shall the Government be liable for any claim, damages or other liability, whether in an action of contract, tort or other dealings in the software. The Government has no obligation hereunder to provide maintenance, support, updates, enhancements, or modifications to the software. Users may submit proposals and/or updates regarding the software, which proposals and/or updates the Government, at its sole discretion, can choose to incorporate into the software. Proposals and/or updates submitted to the Government by users must be accompanied by a license to such proposals and/or updates that is no more restrictive than this License/Disclaimer.</terms_of_use>
-               <sch:ns prefix="oval-sc" uri="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5"/>
-               <sch:ns prefix="linux-sc" uri="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#linux"/>
+               <sch:ns prefix="oval-sc" urn="urn:oval:v6:system-characteristics"/>
+               <sch:ns prefix="linux-sc" urn="urn:oval:v6:system-characteristics:linux"/>
               <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
           </xsd:appinfo>
      </xsd:annotation>

--- a/oval-schemas/macos-definitions-schema.xsd
+++ b/oval-schemas/macos-definitions-schema.xsd
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-            xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5"
-            xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5"
-            xmlns:macos-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#macos"
+            xmlns:oval="urn:oval:v6:common"
+            xmlns:oval-def="urn:oval:v6:definitions"
+            xmlns:macos-def="urn:oval:v6:definitions:macos"
             xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-            targetNamespace="http://oval.mitre.org/XMLSchema/oval-definitions-5#macos"
-            elementFormDefault="qualified" version="5.12">
-      <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-definitions-5" schemaLocation="oval-definitions-schema.xsd"/>
+            targetNamespace="urn:oval:v6:definitions:macos"
+            elementFormDefault="qualified" version="6.0">
+      <xsd:import namespace="urn:oval:v6:definitions" schemaLocation="oval-definitions-schema.xsd"/>
       <xsd:annotation>
             <xsd:documentation>The following is a description of the elements, types, and attributes that compose the MacOS specific tests found in Open Vulnerability and Assessment Language (OVAL). Each test is an extension of the standard test element defined in the Core Definition Schema. Through extension, each test inherits a set of elements and attributes that are shared amongst all OVAL tests. Each test is described in detail and should provide the information necessary to understand what each element and attribute represents. This document is intended for developers and assumes some familiarity with XML. A high level description of the interaction between the different tests and their relationship to the Core Definition Schema is not outlined here.</xsd:documentation>
             <xsd:documentation>The MacOS Definition Schema was initially developed by The Center for Internet Security. Many thanks to their contributions to OVAL and the security community.</xsd:documentation>
             <xsd:documentation>The OVAL Schema is maintained by the OVAL Community. For more information, including how to get involved in the project and how to submit change requests, please visit the OVAL website at https://github.com/OVAL-Community/.</xsd:documentation>
             <xsd:appinfo>
                   <schema>MacOS Definition</schema>
-                  <version>5.12</version>
-                  <date>11/29/2024 09:00:00 AM</date>
+                  <version>6.0</version>
+                  <date>1/1/2025 09:00:00 AM</date>
                   <terms_of_use>This software is an open standard developed by multiple parties, including the United States Government (Government). The Government hereby grants you a non-exclusive, royalty-free, worldwide license to use, modify, and/or reproduce the software for any lawful purpose provided that you reproduce this License/Disclaimer language with any use/modification/copy of the software. The Government assumes no responsibility whatsoever for this software's use by other parties, and the software is provided "AS IS" without warranty or guarantee of any kind, express or implied, including, but not limited to, the warranties of merchantability, fitness for a particular purpose, and noninfringement. In no event shall the Government be liable for any claim, damages or other liability, whether in an action of contract, tort or other dealings in the software. The Government has no obligation hereunder to provide maintenance, support, updates, enhancements, or modifications to the software. Users may submit proposals and/or updates regarding the software, which proposals and/or updates the Government, at its sole discretion, can choose to incorporate into the software. Proposals and/or updates submitted to the Government by users must be accompanied by a license to such proposals and/or updates that is no more restrictive than this License/Disclaimer.</terms_of_use>
-                  <sch:ns prefix="oval-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5"/>
-                  <sch:ns prefix="macos-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5#macos"/>
+                  <sch:ns prefix="oval-def" urn="urn:oval:v6:definitions"/>
+                  <sch:ns prefix="macos-def" urn="urn:oval:v6:definitions:macos"/>
                   <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
             </xsd:appinfo>
       </xsd:annotation>
@@ -32,7 +32,7 @@
                               <oval:test>accountinfo_test</oval:test>
                               <oval:object>accountinfo_object</oval:object>
                               <oval:state>accountinfo_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#macos">accountinfo_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:macos">accountinfo_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -70,7 +70,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#macos') and ($state_name='accountinfo_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:macos') and ($state_name='accountinfo_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -159,7 +159,7 @@
                               <oval:test>authorizationdb_test</oval:test>
                               <oval:object>authorizationdb_object</oval:object>
                               <oval:state>authorizationdb_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#macos">authorizationdb_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:macos">authorizationdb_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -197,7 +197,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#macos') and ($state_name='authorizationdb_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:macos') and ($state_name='authorizationdb_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -273,7 +273,7 @@
                               <oval:test>corestorage_test</oval:test>
                               <oval:object>corestorage_object</oval:object>
                               <oval:state>corestorage_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#macos">corestorage_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:macos">corestorage_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -317,7 +317,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#macos') and ($state_name='corestorage_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:macos') and ($state_name='corestorage_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -393,7 +393,7 @@
                               <oval:test>disabledservice_test</oval:test>
                               <oval:object>disabledservice_object</oval:object>
                               <oval:state>disabledservice_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#macos">disabledservice_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:macos">disabledservice_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -430,7 +430,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#macos') and ($state_name='disabledservice_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:macos') and ($state_name='disabledservice_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -479,7 +479,7 @@
                               <oval:test>diskinfo_test</oval:test>
                               <oval:object>diskinfo_object</oval:object>
                               <oval:state>diskinfo_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#macos">diskinfo_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:macos">diskinfo_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -521,7 +521,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#macos') and ($state_name='diskinfo_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:macos') and ($state_name='diskinfo_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -636,7 +636,7 @@
                               <oval:test>diskutil_test</oval:test>
                               <oval:object>diskutil_object</oval:object>
                               <oval:state>diskutil_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#macos">diskutil_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:macos">diskutil_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 				  	<xsd:appinfo>
@@ -703,7 +703,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#macos') and ($state_name='diskutil_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:macos') and ($state_name='diskutil_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -871,7 +871,7 @@
                               <oval:test>filevault_test</oval:test>
                               <oval:object>filevault_object</oval:object>
                               <oval:state>filevault_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#macos">filevault_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:macos">filevault_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -910,7 +910,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#macos') and ($state_name='filevault_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:macos') and ($state_name='filevault_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -966,7 +966,7 @@
                               <oval:test>firmwarepassword_test</oval:test>
                               <oval:object>firmwarepassword_object</oval:object>
                               <oval:state>firmwarepassword_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#macos">firmwarepassword_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:macos">firmwarepassword_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -1005,7 +1005,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#macos') and ($state_name='firmwarepassword_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:macos') and ($state_name='firmwarepassword_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -1045,7 +1045,7 @@
                               <oval:test>gatekeeper_test</oval:test>
                               <oval:object>gatekeeper_object</oval:object>
                               <oval:state>gatekeeper_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#macos">gatekeeper_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:macos">gatekeeper_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -1119,7 +1119,7 @@
                               <oval:test>inetlisteningservers_test</oval:test>
                               <oval:object>inetlisteningservers_object</oval:object>
                               <oval:state>inetlisteningservers_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#macos">inetlisteningserver_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:macos">inetlisteningserver_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -1178,7 +1178,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#macos') and ($state_name='inetlisteningservers_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:macos') and ($state_name='inetlisteningservers_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -1288,7 +1288,7 @@
                               <oval:test>inetlisteningserver510_test</oval:test>
                               <oval:object>inetlisteningserver510_object</oval:object>
                               <oval:state>inetlisteningserver510_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#macos">inetlisteningserver510_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:macos">inetlisteningserver510_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -1331,7 +1331,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#macos') and ($state_name='inetlisteningserver510_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:macos') and ($state_name='inetlisteningserver510_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -1445,7 +1445,7 @@
                               <oval:test>installhistory_test</oval:test>
                               <oval:object>installhistory_object</oval:object>
                               <oval:state>installhistory_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#macos">installhistory_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:macos">installhistory_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -1487,7 +1487,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#macos') and ($state_name='installhistory_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:macos') and ($state_name='installhistory_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -1565,7 +1565,7 @@
                               <oval:test>keychain_test</oval:test>
                               <oval:object>keychain_object</oval:object>
                               <oval:state>keychain_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#macos">keychain_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:macos">keychain_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -1603,7 +1603,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#macos') and ($state_name='keychain_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:macos') and ($state_name='keychain_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -1667,7 +1667,7 @@
                               <oval:test>launchd_test</oval:test>
                               <oval:object>launchd_object</oval:object>
                               <oval:state>launchd_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#macos">launchd_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:macos">launchd_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -1705,7 +1705,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#macos') and ($state_name='launchd_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:macos') and ($state_name='launchd_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -1769,7 +1769,7 @@
                               <oval:test>nvram_test</oval:test>
                               <oval:object>nvram_object</oval:object>
                               <oval:state>nvram_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#macos">nvram_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:macos">nvram_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -1812,7 +1812,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#macos') and ($state_name='nvram_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:macos') and ($state_name='nvram_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -1871,7 +1871,7 @@
                               <oval:test>nvram512_test</oval:test>
                               <oval:object>nvram512_object</oval:object>
                               <oval:state>nvram512_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#macos">nvram512_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:macos">nvram512_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -1908,7 +1908,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#macos') and ($state_name='nvram512_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:macos') and ($state_name='nvram512_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -1967,7 +1967,7 @@
                               <oval:test>plist_test</oval:test>
                               <oval:object>plist_object</oval:object>
                               <oval:state>plist_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#macos">plist_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:macos">plist_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -2029,7 +2029,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#macos') and ($state_name='plist_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:macos') and ($state_name='plist_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -2140,7 +2140,7 @@
                               <oval:test>plist510_test</oval:test>
                               <oval:object>plist510_object</oval:object>
                               <oval:state>plist510_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#macos">plist_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:macos">plist_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -2202,7 +2202,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#macos') and ($state_name='plist510_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:macos') and ($state_name='plist510_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -2363,7 +2363,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#macos') and ($state_name='plist511_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:macos') and ($state_name='plist511_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -2462,7 +2462,7 @@
                               <oval:test>profiles_test</oval:test>
                               <oval:object>profiles_object</oval:object>
                               <oval:state>profiles_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#macos">profiles_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:macos">profiles_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -2501,7 +2501,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#macos') and ($state_name='profiles_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:macos') and ($state_name='profiles_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -2546,7 +2546,7 @@
                               <oval:test>pwpolicy_test</oval:test>
                               <oval:object>pwpolicy_object</oval:object>
                               <oval:state>pwpolicy_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#macos">pwpolicy_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:macos">pwpolicy_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -2607,7 +2607,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#macos') and ($state_name='pwpolicy_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:macos') and ($state_name='pwpolicy_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -2744,7 +2744,7 @@
                               <oval:test>pwpolicy59_test</oval:test>
                               <oval:object>pwpolicy59_object</oval:object>
                               <oval:state>pwpolicy59_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#macos">pwpolicy59_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:macos">pwpolicy59_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 				  <xsd:appinfo>
@@ -2787,7 +2787,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#macos') and ($state_name='pwpolicy59_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:macos') and ($state_name='pwpolicy59_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -2998,7 +2998,7 @@
                               <oval:test>pwpolicy512_test</oval:test>
                               <oval:object>pwpolicy512_object</oval:object>
                               <oval:state>pwpolicy512_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#macos">pwpolicy512_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:macos">pwpolicy512_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -3035,7 +3035,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#macos') and ($state_name='pwpolicy512_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:macos') and ($state_name='pwpolicy512_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -3163,7 +3163,7 @@
                               <oval:test>rlimit_test</oval:test>
                               <oval:object>rlimit_object</oval:object>
                               <oval:state>rlimit_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#macos">rlimit_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:macos">rlimit_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -3320,7 +3320,7 @@
                               <oval:test>softwareupdate_test</oval:test>
                               <oval:object>softwareupdate_object</oval:object>
                               <oval:state>softwareupdate_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#macos">softwareupdate_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:macos">softwareupdate_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -3389,7 +3389,7 @@
                               <oval:test>systemprofiler_test</oval:test>
                               <oval:object>systemprofiler_object</oval:object>
                               <oval:state>systemprofiler_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#macos">systemprofiler_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:macos">systemprofiler_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -3427,7 +3427,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#macos') and ($state_name='systemprofiler_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:macos') and ($state_name='systemprofiler_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -3503,7 +3503,7 @@
                               <oval:test>systemsetup_test</oval:test>
                               <oval:object>systemsetup_object</oval:object>
                               <oval:state>systemsetup_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#macos">systemsetup_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:macos">systemsetup_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>

--- a/oval-schemas/macos-system-characteristics-schema.xsd
+++ b/oval-schemas/macos-system-characteristics-schema.xsd
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-            xmlns:oval-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5"
-            xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5"
-            xmlns:macos-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#macos"
+            xmlns:oval-sc="urn:oval:v6:system-characteristics"
+            xmlns:oval="urn:oval:v6:common"
+            xmlns:macos-sc="urn:oval:v6:system-characteristics:macos"
             xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-            targetNamespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#macos"
-            elementFormDefault="qualified" version="5.12">
-     <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5" schemaLocation="oval-system-characteristics-schema.xsd"/>
+            targetNamespace="urn:oval:v6:system-characteristics:macos"
+            elementFormDefault="qualified" version="6.0">
+     <xsd:import namespace="urn:oval:v6:system-characteristics" schemaLocation="oval-system-characteristics-schema.xsd"/>
      <xsd:annotation>
           <xsd:documentation>The following is a description of the elements, types, and attributes that compose the MacOS specific system characteristic items found in Open Vulnerability and Assessment Language (OVAL). Each item is an extension of the standard test element defined in the Core Definition Schema. Through extension, each test inherits a set of elements and attributes that are shared amongst all OVAL tests. Each test is described in detail and should provide the information necessary to understand what each element and attribute represents. This document is intended for developers and assumes some familiarity with XML. A high level description of the interaction between the different tests and their relationship to the Core Definition Schema is not outlined here.</xsd:documentation>
           <xsd:documentation>The MacOS System Characteristics Schema was initially developed by The Center for Internet Security. Many thanks to their contributions to OVAL and the security community.</xsd:documentation>
           <xsd:documentation>The OVAL Schema is maintained by the OVAL Community. For more information, including how to get involved in the project and how to submit change requests, please visit the OVAL website at https://github.com/OVAL-Community/.</xsd:documentation>
           <xsd:appinfo>
                <schema>MacOS System Characteristics</schema>
-               <version>5.12</version>
-               <date>11/29/2024 09:00:00 AM</date>
+               <version>6.0</version>
+               <date>1/1/2025 09:00:00 AM</date>
                 <terms_of_use>This software is an open standard developed by multiple parties, including the United States Government (Government). The Government hereby grants you a non-exclusive, royalty-free, worldwide license to use, modify, and/or reproduce the software for any lawful purpose provided that you reproduce this License/Disclaimer language with any use/modification/copy of the software. The Government assumes no responsibility whatsoever for this software's use by other parties, and the software is provided "AS IS" without warranty or guarantee of any kind, express or implied, including, but not limited to, the warranties of merchantability, fitness for a particular purpose, and noninfringement. In no event shall the Government be liable for any claim, damages or other liability, whether in an action of contract, tort or other dealings in the software. The Government has no obligation hereunder to provide maintenance, support, updates, enhancements, or modifications to the software. Users may submit proposals and/or updates regarding the software, which proposals and/or updates the Government, at its sole discretion, can choose to incorporate into the software. Proposals and/or updates submitted to the Government by users must be accompanied by a license to such proposals and/or updates that is no more restrictive than this License/Disclaimer.</terms_of_use>
-               <sch:ns prefix="oval-sc" uri="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5"/>
-               <sch:ns prefix="macos-sc" uri="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#macos"/>
+               <sch:ns prefix="oval-sc" urn="urn:oval:v6:system-characteristics"/>
+               <sch:ns prefix="macos-sc" urn="urn:oval:v6:system-characteristics:macos"/>
               <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
           </xsd:appinfo>
      </xsd:annotation>

--- a/oval-schemas/netconf-definitions-schema.xsd
+++ b/oval-schemas/netconf-definitions-schema.xsd
@@ -1,22 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-            xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5"
-            xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5"
-            xmlns:netconf-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#netconf"
+            xmlns:oval="urn:oval:v6:common"
+            xmlns:oval-def="urn:oval:v6:definitions"
+            xmlns:netconf-def="urn:oval:v6:definitions:netconf"
             xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-            targetNamespace="http://oval.mitre.org/XMLSchema/oval-definitions-5#netconf"
-            elementFormDefault="qualified" version="5.12">
-    <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-definitions-5" schemaLocation="oval-definitions-schema.xsd"/>
+            targetNamespace="urn:oval:v6:definitions:netconf"
+            elementFormDefault="qualified" version="6.0">
+    <xsd:import namespace="urn:oval:v6:definitions" schemaLocation="oval-definitions-schema.xsd"/>
     <xsd:annotation>
         <xsd:documentation>The following is a description of the elements, types, and attributes that compose the NETCONF (RFC 6241) protocol-specific tests found in Open Vulnerability and Assessment Language (OVAL). Each test is an extension of the standard test element defined in the Core Definition Schema. Through extension, each test inherits a set of elements and attributes that are shared amongst all OVAL tests. Each test is described in detail and should provide the information necessary to understand what each element and attribute represents. This document is intended for developers and assumes some familiarity with XML. A high level description of the interaction between the different tests and their relationship to the Core Definition Schema is not outlined here</xsd:documentation>
         <xsd:documentation>This schema was originally developed by David Solin at jOVAL.org. The OVAL Schema is maintained by the OVAL Community. For more information, including how to get involved in the project and how to submit change requests, please visit the OVAL website at https://github.com/OVAL-Community/.</xsd:documentation>
         <xsd:appinfo>
             <schema>NETCONF Definitions</schema>
-            <version>5.12</version>
-            <date>11/29/2024 09:00:00 AM</date>
+            <version>6.0</version>
+            <date>1/1/2025 09:00:00 AM</date>
             <terms_of_use>This software is an open standard developed by multiple parties, including the United States Government (Government). The Government hereby grants you a non-exclusive, royalty-free, worldwide license to use, modify, and/or reproduce the software for any lawful purpose provided that you reproduce this License/Disclaimer language with any use/modification/copy of the software. The Government assumes no responsibility whatsoever for this software's use by other parties, and the software is provided "AS IS" without warranty or guarantee of any kind, express or implied, including, but not limited to, the warranties of merchantability, fitness for a particular purpose, and noninfringement. In no event shall the Government be liable for any claim, damages or other liability, whether in an action of contract, tort or other dealings in the software. The Government has no obligation hereunder to provide maintenance, support, updates, enhancements, or modifications to the software. Users may submit proposals and/or updates regarding the software, which proposals and/or updates the Government, at its sole discretion, can choose to incorporate into the software. Proposals and/or updates submitted to the Government by users must be accompanied by a license to such proposals and/or updates that is no more restrictive than this License/Disclaimer.</terms_of_use>
-            <sch:ns prefix="oval-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5"/>
-            <sch:ns prefix="netconf-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5#netconf"/>
+            <sch:ns prefix="oval-def" urn="urn:oval:v6:definitions"/>
+            <sch:ns prefix="netconf-def" urn="urn:oval:v6:definitions:netconf"/>
             <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
         </xsd:appinfo>
     </xsd:annotation>
@@ -31,7 +31,7 @@
                     <oval:test>config_test</oval:test>
                     <oval:object>config_object</oval:object>
                     <oval:state>config_state</oval:state>
-                    <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#netconf">config_item</oval:item>
+                    <oval:item target_namespace="urn:oval:v6:system-characteristics:netconf">config_item</oval:item>
                 </oval:element_mapping>
             </xsd:appinfo>
 			<xsd:appinfo>
@@ -75,7 +75,7 @@
                         <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                         <sch:let name="state_name" value="local-name($reffed_state)"/>
                         <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                        <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#netconf') and ($state_name='config_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                        <sch:assert test="(($state_namespace='urn:oval:v6:definitions:netconf') and ($state_name='config_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                     </sch:rule>
                 </sch:pattern>
             </xsd:appinfo>

--- a/oval-schemas/netconf-system-characteristics-schema.xsd
+++ b/oval-schemas/netconf-system-characteristics-schema.xsd
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-            xmlns:oval-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5"
-            xmlns:netconf-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#netconf"
+            xmlns:oval-sc="urn:oval:v6:system-characteristics"
+            xmlns:netconf-sc="urn:oval:v6:system-characteristics:netconf"
             xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-            targetNamespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#netconf"
-            elementFormDefault="qualified" version="5.12">
-    <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5" schemaLocation="oval-system-characteristics-schema.xsd"/>
+            targetNamespace="urn:oval:v6:system-characteristics:netconf"
+            elementFormDefault="qualified" version="6.0">
+    <xsd:import namespace="urn:oval:v6:system-characteristics" schemaLocation="oval-system-characteristics-schema.xsd"/>
     <xsd:annotation>
         <xsd:documentation>This document outlines the items of the OVAL System Characteristics XML schema that are composed of NETCONF (RFC 6241) protocol-specific tests. Each item is an extention of a basic System Characteristics item defined in the core System Characteristics XML schema.</xsd:documentation>
         <xsd:documentation>This schema was originally developed by David Solin at jOVAL.org. The OVAL Schema is maintained by the OVAL Community. For more information, including how to get involved in the project and how to submit change requests, please visit the OVAL website at https://github.com/OVAL-Community/.</xsd:documentation>
         <xsd:appinfo>
             <schema>NETCONF System Characteristics</schema>
-            <version>5.12</version>
-            <date>11/29/2024 09:00:00 AM</date>
+            <version>6.0</version>
+            <date>1/1/2025 09:00:00 AM</date>
             <terms_of_use>This software is an open standard developed by multiple parties, including the United States Government (Government). The Government hereby grants you a non-exclusive, royalty-free, worldwide license to use, modify, and/or reproduce the software for any lawful purpose provided that you reproduce this License/Disclaimer language with any use/modification/copy of the software. The Government assumes no responsibility whatsoever for this software's use by other parties, and the software is provided "AS IS" without warranty or guarantee of any kind, express or implied, including, but not limited to, the warranties of merchantability, fitness for a particular purpose, and noninfringement. In no event shall the Government be liable for any claim, damages or other liability, whether in an action of contract, tort or other dealings in the software. The Government has no obligation hereunder to provide maintenance, support, updates, enhancements, or modifications to the software. Users may submit proposals and/or updates regarding the software, which proposals and/or updates the Government, at its sole discretion, can choose to incorporate into the software. Proposals and/or updates submitted to the Government by users must be accompanied by a license to such proposals and/or updates that is no more restrictive than this License/Disclaimer.</terms_of_use>
-            <sch:ns prefix="oval-sc" uri="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5"/>
-            <sch:ns prefix="netconf-sc" uri="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#netconf"/>
+            <sch:ns prefix="oval-sc" urn="urn:oval:v6:system-characteristics"/>
+            <sch:ns prefix="netconf-sc" urn="urn:oval:v6:system-characteristics:netconf"/>
             <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
         </xsd:appinfo>
     </xsd:annotation>

--- a/oval-schemas/oval-common-schema.xsd
+++ b/oval-schemas/oval-common-schema.xsd
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-            xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5"
+            xmlns:oval="urn:oval:v6:common"
             xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-            targetNamespace="http://oval.mitre.org/XMLSchema/oval-common-5"
-            elementFormDefault="qualified" version="5.12">
+            targetNamespace="urn:oval:v6:common"
+            elementFormDefault="qualified" version="6.0">
      <xsd:annotation>
           <xsd:documentation>The following is a description of the common types that are shared across the different schemas within Open Vulnerability and Assessment Language (OVAL). Each type is described in detail and should provide the information necessary to understand what each represents. This document is intended for developers and assumes some familiarity with XML. A high level description of the interaction between these type is not outlined here.</xsd:documentation>
           <xsd:documentation>The OVAL Schema is maintained by the OVAL Community. For more information, including how to get involved in the project and how to submit change requests, please visit the OVAL website at https://github.com/OVAL-Community/.</xsd:documentation>
           <xsd:appinfo>
                <schema>Core Common</schema>
-               <version>5.12</version>
-               <date>11/29/2024 09:00:00 AM</date>
+               <version>6.0</version>
+               <date>1/1/2025 09:00:00 AM</date>
                <terms_of_use>This software is an open standard developed by multiple parties, including the United States Government (Government). The Government hereby grants you a non-exclusive, royalty-free, worldwide license to use, modify, and/or reproduce the software for any lawful purpose provided that you reproduce this License/Disclaimer language with any use/modification/copy of the software. The Government assumes no responsibility whatsoever for this software's use by other parties, and the software is provided "AS IS" without warranty or guarantee of any kind, express or implied, including, but not limited to, the warranties of merchantability, fitness for a particular purpose, and noninfringement. In no event shall the Government be liable for any claim, damages or other liability, whether in an action of contract, tort or other dealings in the software. The Government has no obligation hereunder to provide maintenance, support, updates, enhancements, or modifications to the software. Users may submit proposals and/or updates regarding the software, which proposals and/or updates the Government, at its sole discretion, can choose to incorporate into the software. Proposals and/or updates submitted to the Government by users must be accompanied by a license to such proposals and/or updates that is no more restrictive than this License/Disclaimer.</terms_of_use>
-               <sch:ns prefix="oval" uri="http://oval.mitre.org/XMLSchema/oval-common-5"/>
-               <sch:ns prefix="oval-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5"/>
+               <sch:ns prefix="oval" urn="urn:oval:v6:common"/>
+               <sch:ns prefix="oval-def" urn="urn:oval:v6:definitions"/>
           </xsd:appinfo>
      </xsd:annotation>
      <!-- =============================================================================== -->

--- a/oval-schemas/oval-definitions-schema.xsd
+++ b/oval-schemas/oval-definitions-schema.xsd
@@ -1,22 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-            xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5"
-            xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5"
+            xmlns:oval="urn:oval:v6:common"
+            xmlns:oval-def="urn:oval:v6:definitions"
             xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
             xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-            targetNamespace="http://oval.mitre.org/XMLSchema/oval-definitions-5"
-            elementFormDefault="qualified" version="5.12">
-    <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-common-5" schemaLocation="oval-common-schema.xsd"/>
+            targetNamespace="urn:oval:v6:definitions"
+            elementFormDefault="qualified" version="6.0">
+    <xsd:import namespace="urn:oval:v6:common" schemaLocation="oval-common-schema.xsd"/>
     <xsd:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="xmldsig-core-schema.xsd"/>
     <xsd:annotation>
         <xsd:documentation>The following is a description of the elements, types, and attributes that compose the core schema for encoding Open Vulnerability and Assessment Language (OVAL) Definitions. Some of the objects defined here are extended and enhanced by individual component schemas, which are described in separate documents. Each of the elements, types, and attributes that make up the Core Definition Schema are described in detail and should provide the information necessary to understand what each represents. This document is intended for developers and assumes some familiarity with XML. A high level description of the interaction between these objects is not outlined here.</xsd:documentation>
         <xsd:documentation>The OVAL Schema is maintained by OVAL Community. For more information, including how to get involved in the project and how to submit change requests, please visit the OVAL website at https://github.com/OVAL-Community/.</xsd:documentation>
         <xsd:appinfo>
             <schema>Core Definition</schema>
-            <version>5.12</version>
-            <date>11/29/2024 09:00:00 AM</date>
+            <version>6.0</version>
+            <date>1/1/2025 09:00:00 AM</date>
             <terms_of_use>This software is an open standard developed by multiple parties, including the United States Government (Government). The Government hereby grants you a non-exclusive, royalty-free, worldwide license to use, modify, and/or reproduce the software for any lawful purpose provided that you reproduce this License/Disclaimer language with any use/modification/copy of the software. The Government assumes no responsibility whatsoever for this software's use by other parties, and the software is provided "AS IS" without warranty or guarantee of any kind, express or implied, including, but not limited to, the warranties of merchantability, fitness for a particular purpose, and noninfringement. In no event shall the Government be liable for any claim, damages or other liability, whether in an action of contract, tort or other dealings in the software. The Government has no obligation hereunder to provide maintenance, support, updates, enhancements, or modifications to the software. Users may submit proposals and/or updates regarding the software, which proposals and/or updates the Government, at its sole discretion, can choose to incorporate into the software. Proposals and/or updates submitted to the Government by users must be accompanied by a license to such proposals and/or updates that is no more restrictive than this License/Disclaimer.</terms_of_use>
-            <sch:ns prefix="oval-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5"/>
+            <sch:ns prefix="oval-def" urn="urn:oval:v6:definitions"/>
             <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
         </xsd:appinfo>
     </xsd:annotation>

--- a/oval-schemas/oval-directives-schema.xsd
+++ b/oval-schemas/oval-directives-schema.xsd
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-            xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5"
-            xmlns:oval-res="http://oval.mitre.org/XMLSchema/oval-results-5"
+            xmlns:oval="urn:oval:v6:common"
+            xmlns:oval-res="urn:oval:v6:results"
             xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
             xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-            xmlns:oval-dir="http://oval.mitre.org/XMLSchema/oval-directives-5"
-            targetNamespace="http://oval.mitre.org/XMLSchema/oval-directives-5"
-            elementFormDefault="qualified" version="5.12">
-     <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-common-5" schemaLocation="oval-common-schema.xsd"/>
-     <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-results-5" schemaLocation="oval-results-schema.xsd"/>
+            xmlns:oval-dir="urn:oval:v6:directives"
+            targetNamespace="urn:oval:v6:directives"
+            elementFormDefault="qualified" version="6.0">
+     <xsd:import namespace="urn:oval:v6:common" schemaLocation="oval-common-schema.xsd"/>
+     <xsd:import namespace="urn:oval:v6:results" schemaLocation="oval-results-schema.xsd"/>
      <xsd:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="xmldsig-core-schema.xsd"/>
      <xsd:annotation>
           <xsd:documentation>The following is a description of the elements, types, and attributes that compose the core schema for encoding Open Vulnerability and Assessment Language (OVAL) Directives. Each of the elements, types, and attributes that make up the Core Directives Schema are described in detail and should provide the information necessary to understand what each object represents. This document is intended for developers and assumes some familiarity with XML. A high level description of the interaction between these objects is not outlined here.</xsd:documentation>
           <xsd:documentation>The OVAL Schema is maintained by The MITRE Corporation and developed by the public OVAL Community. For more information, including how to get involved in the project and how to submit change requests, please visit the OVAL website at http://oval.mitre.org.</xsd:documentation>
           <xsd:appinfo>
                <schema>Core Directives</schema>
-               <version>5.12</version>
-               <date>11/29/2024 09:00:00 AM</date>
+               <version>6.0</version>
+               <date>1/1/2025 09:00:00 AM</date>
                <terms_of_use>This software is an open standard developed by multiple parties, including the United States Government (Government). The Government hereby grants you a non-exclusive, royalty-free, worldwide license to use, modify, and/or reproduce the software for any lawful purpose provided that you reproduce this License/Disclaimer language with any use/modification/copy of the software. The Government assumes no responsibility whatsoever for this software's use by other parties, and the software is provided "AS IS" without warranty or guarantee of any kind, express or implied, including, but not limited to, the warranties of merchantability, fitness for a particular purpose, and noninfringement. In no event shall the Government be liable for any claim, damages or other liability, whether in an action of contract, tort or other dealings in the software. The Government has no obligation hereunder to provide maintenance, support, updates, enhancements, or modifications to the software. Users may submit proposals and/or updates regarding the software, which proposals and/or updates the Government, at its sole discretion, can choose to incorporate into the software. Proposals and/or updates submitted to the Government by users must be accompanied by a license to such proposals and/or updates that is no more restrictive than this License/Disclaimer.</terms_of_use>
-               <sch:ns prefix="oval-dir" uri="http://oval.mitre.org/XMLSchema/oval-directives-5"/>
+               <sch:ns prefix="oval-dir" urn="urn:oval:v6:directives"/>
           </xsd:appinfo>
      </xsd:annotation>
      <!-- =============================================================================== -->

--- a/oval-schemas/oval-results-schema.xsd
+++ b/oval-schemas/oval-results-schema.xsd
@@ -1,26 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-            xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5"
-            xmlns:oval-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5"
-            xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5"
-            xmlns:oval-res="http://oval.mitre.org/XMLSchema/oval-results-5"
+            xmlns:oval="urn:oval:v6:common"
+            xmlns:oval-sc="urn:oval:v6:system-characteristics"
+            xmlns:oval-def="urn:oval:v6:definitions"
+            xmlns:oval-res="urn:oval:v6:results"
             xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
             xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-            targetNamespace="http://oval.mitre.org/XMLSchema/oval-results-5"
-            elementFormDefault="qualified" version="5.12">
-     <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-common-5" schemaLocation="oval-common-schema.xsd"/>
-     <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-definitions-5" schemaLocation="oval-definitions-schema.xsd"/>
-     <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5" schemaLocation="oval-system-characteristics-schema.xsd"/>
+            targetNamespace="urn:oval:v6:results"
+            elementFormDefault="qualified" version="6.0">
+     <xsd:import namespace="urn:oval:v6:common" schemaLocation="oval-common-schema.xsd"/>
+     <xsd:import namespace="urn:oval:v6:definitions" schemaLocation="oval-definitions-schema.xsd"/>
+     <xsd:import namespace="urn:oval:v6:system-characteristics" schemaLocation="oval-system-characteristics-schema.xsd"/>
      <xsd:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="xmldsig-core-schema.xsd"/>
      <xsd:annotation>
           <xsd:documentation>The following is a description of the elements, types, and attributes that compose the core schema for encoding Open Vulnerability and Assessment Language (OVAL) Results. Each of the elements, types, and attributes that make up the Core Results Schema are described in detail and should provide the information necessary to understand what each object represents. This document is intended for developers and assumes some familiarity with XML. A high level description of the interaction between these objects is not outlined here.</xsd:documentation>
           <xsd:documentation>The OVAL Schema is maintained by the OVAL Community. For more information, including how to get involved in the project and how to submit change requests, please visit the OVAL website at https://github.com/OVAL-Community/.</xsd:documentation>
           <xsd:appinfo>
                <schema>Core Results</schema>
-               <version>5.12</version>
-               <date>11/29/2024 09:00:00 AM</date>
+               <version>6.0</version>
+               <date>1/1/2025 09:00:00 AM</date>
                 <terms_of_use>This software is an open standard developed by multiple parties, including the United States Government (Government). The Government hereby grants you a non-exclusive, royalty-free, worldwide license to use, modify, and/or reproduce the software for any lawful purpose provided that you reproduce this License/Disclaimer language with any use/modification/copy of the software. The Government assumes no responsibility whatsoever for this software's use by other parties, and the software is provided "AS IS" without warranty or guarantee of any kind, express or implied, including, but not limited to, the warranties of merchantability, fitness for a particular purpose, and noninfringement. In no event shall the Government be liable for any claim, damages or other liability, whether in an action of contract, tort or other dealings in the software. The Government has no obligation hereunder to provide maintenance, support, updates, enhancements, or modifications to the software. Users may submit proposals and/or updates regarding the software, which proposals and/or updates the Government, at its sole discretion, can choose to incorporate into the software. Proposals and/or updates submitted to the Government by users must be accompanied by a license to such proposals and/or updates that is no more restrictive than this License/Disclaimer.</terms_of_use>
-               <sch:ns prefix="oval-res" uri="http://oval.mitre.org/XMLSchema/oval-results-5"/>
+               <sch:ns prefix="oval-res" urn="urn:oval:v6:results"/>
           </xsd:appinfo>
      </xsd:annotation>
      <!-- =============================================================================== -->

--- a/oval-schemas/oval-system-characteristics-schema.xsd
+++ b/oval-schemas/oval-system-characteristics-schema.xsd
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-            xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5"
-            xmlns:oval-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5"
+            xmlns:oval="urn:oval:v6:common"
+            xmlns:oval-sc="urn:oval:v6:system-characteristics"
             xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
             xmlns:sch="http://purl.oclc.org/dsdl/schematron"
             xmlns:tns="http://scap.nist.gov/schema/asset-identification/1.1"
-            targetNamespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5"
-            elementFormDefault="qualified" version="5.12">
-    <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-common-5" schemaLocation="oval-common-schema.xsd"/>
+            targetNamespace="urn:oval:v6:system-characteristics"
+            elementFormDefault="qualified" version="6.0">
+    <xsd:import namespace="urn:oval:v6:common" schemaLocation="oval-common-schema.xsd"/>
     <xsd:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="xmldsig-core-schema.xsd"/>
     <xsd:annotation>
         <xsd:documentation>The following is a description of the elements, types, and attributes that compose the core schema for encoding Open Vulnerability and Assessment Language (OVAL) System Characteristics. The Core System Characteristics Schema defines all operating system independent objects. These objects are extended and enhanced by individual family schemas, which are described in separate documents. Each of the elements, types, and attributes that make up the Core System Characteristics Schema are described in detail and should provide the information necessary to understand what each object represents. This document is intended for developers and assumes some familiarity with XML. A high level description of the interaction between these objects is not outlined here.</xsd:documentation>
         <xsd:documentation>The OVAL Schema is maintained by the OVAL Community. For more information, including how to get involved in the project and how to submit change requests, please visit the OVAL website at https://github.com/OVAL-Community/.</xsd:documentation>
         <xsd:appinfo>
             <schema>Core System Characteristics</schema>
-            <version>5.12</version>
-            <date>11/29/2024 09:00:00 AM</date>
+            <version>6.0</version>
+            <date>1/1/2025 09:00:00 AM</date>
             <terms_of_use>This software is an open standard developed by multiple parties, including the United States Government (Government). The Government hereby grants you a non-exclusive, royalty-free, worldwide license to use, modify, and/or reproduce the software for any lawful purpose provided that you reproduce this License/Disclaimer language with any use/modification/copy of the software. The Government assumes no responsibility whatsoever for this software's use by other parties, and the software is provided "AS IS" without warranty or guarantee of any kind, express or implied, including, but not limited to, the warranties of merchantability, fitness for a particular purpose, and noninfringement. In no event shall the Government be liable for any claim, damages or other liability, whether in an action of contract, tort or other dealings in the software. The Government has no obligation hereunder to provide maintenance, support, updates, enhancements, or modifications to the software. Users may submit proposals and/or updates regarding the software, which proposals and/or updates the Government, at its sole discretion, can choose to incorporate into the software. Proposals and/or updates submitted to the Government by users must be accompanied by a license to such proposals and/or updates that is no more restrictive than this License/Disclaimer.</terms_of_use>
-            <sch:ns prefix="oval-sc" uri="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5"/>
+            <sch:ns prefix="oval-sc" urn="urn:oval:v6:system-characteristics"/>
             <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
         </xsd:appinfo>
     </xsd:annotation>

--- a/oval-schemas/oval-variables-schema.xsd
+++ b/oval-schemas/oval-variables-schema.xsd
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-            xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5"
-            xmlns:oval-var="http://oval.mitre.org/XMLSchema/oval-variables-5"
+            xmlns:oval="urn:oval:v6:common"
+            xmlns:oval-var="urn:oval:v6:variables"
             xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
             xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-            targetNamespace="http://oval.mitre.org/XMLSchema/oval-variables-5"
-            elementFormDefault="qualified" version="5.12">
-     <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-common-5" schemaLocation="oval-common-schema.xsd"/>
+            targetNamespace="urn:oval:v6:variables"
+            elementFormDefault="qualified" version="6.0">
+     <xsd:import namespace="urn:oval:v6:common" schemaLocation="oval-common-schema.xsd"/>
      <xsd:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="xmldsig-core-schema.xsd"/>
      <xsd:annotation>
           <xsd:documentation/>
@@ -14,10 +14,10 @@
           <xsd:documentation>The OVAL Schema is maintained by The MITRE Corporation and developed by the public OVAL Community. For more information, including how to get involved in the project and how to submit change requests, please visit the OVAL website at http://oval.mitre.org.</xsd:documentation>
           <xsd:appinfo>
                <schema>Core Variable</schema>
-               <version>5.12</version>
-               <date>11/29/2024 09:00:00 AM</date>
+               <version>6.0</version>
+               <date>1/1/2025 09:00:00 AM</date>
                <terms_of_use>This software is an open standard developed by multiple parties, including the United States Government (Government). The Government hereby grants you a non-exclusive, royalty-free, worldwide license to use, modify, and/or reproduce the software for any lawful purpose provided that you reproduce this License/Disclaimer language with any use/modification/copy of the software. The Government assumes no responsibility whatsoever for this software's use by other parties, and the software is provided "AS IS" without warranty or guarantee of any kind, express or implied, including, but not limited to, the warranties of merchantability, fitness for a particular purpose, and noninfringement. In no event shall the Government be liable for any claim, damages or other liability, whether in an action of contract, tort or other dealings in the software. The Government has no obligation hereunder to provide maintenance, support, updates, enhancements, or modifications to the software. Users may submit proposals and/or updates regarding the software, which proposals and/or updates the Government, at its sole discretion, can choose to incorporate into the software. Proposals and/or updates submitted to the Government by users must be accompanied by a license to such proposals and/or updates that is no more restrictive than this License/Disclaimer.</terms_of_use>
-              <sch:ns prefix="oval-var" uri="http://oval.mitre.org/XMLSchema/oval-variables-5"/>
+              <sch:ns prefix="oval-var" urn="urn:oval:v6:variables"/>
           </xsd:appinfo>
      </xsd:annotation>
      <!-- =============================================================================== -->

--- a/oval-schemas/panos-definitions-schema.xsd
+++ b/oval-schemas/panos-definitions-schema.xsd
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-            xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5"
-            xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5"
-            xmlns:panos-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#panos"
+            xmlns:oval="urn:oval:v6:common"
+            xmlns:oval-def="urn:oval:v6:definitions"
+            xmlns:panos-def="urn:oval:v6:definitions:panos"
             xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-            targetNamespace="http://oval.mitre.org/XMLSchema/oval-definitions-5#panos"
-            elementFormDefault="qualified" version="5.12">
-    <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-definitions-5" schemaLocation="oval-definitions-schema.xsd"/>
+            targetNamespace="urn:oval:v6:definitions:panos"
+            elementFormDefault="qualified" version="6.0">
+    <xsd:import namespace="urn:oval:v6:definitions" schemaLocation="oval-definitions-schema.xsd"/>
     <xsd:annotation>
         <xsd:documentation>
             The following is a description of the elements, types, and attributes that compose the Palo Alto (PAN-OS)-specific 
@@ -24,8 +24,8 @@
         </xsd:documentation>
         <xsd:appinfo>
             <schema>Palo Alto (PAN-OS) Definitions</schema>
-            <version>5.12</version>
-            <date>11/29/2024 09:00:00 AM</date>
+            <version>6.0</version>
+            <date>1/1/2025 09:00:00 AM</date>
             <terms_of_use>
                 For the portion subject to the copyright in the United States: Copyright (c) 2016 United States Government. 
                 All rights reserved. Copyright (c) 2016, Center for Internet Security. All rights reserved. The contents of 
@@ -33,8 +33,8 @@
                 OVAL License for the specific language governing permissions and limitations for use of this schema. When 
                 distributing copies of the OVAL Schema, this license header must be included.
             </terms_of_use>
-            <sch:ns prefix="oval-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5"/>
-            <sch:ns prefix="panos-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5#panos"/>
+            <sch:ns prefix="oval-def" urn="urn:oval:v6:definitions"/>
+            <sch:ns prefix="panos-def" urn="urn:oval:v6:definitions:panos"/>
             <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
         </xsd:appinfo>
     </xsd:annotation>
@@ -57,7 +57,7 @@
                     <oval:test>config_test</oval:test>
                     <oval:object>config_object</oval:object>
                     <oval:state>config_state</oval:state>
-                    <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#panos">config_item</oval:item>
+                    <oval:item target_namespace="urn:oval:v6:system-characteristics:panos">config_item</oval:item>
                 </oval:element_mapping>
             </xsd:appinfo>
             <xsd:appinfo>
@@ -104,7 +104,7 @@
                         <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                         <sch:let name="state_name" value="local-name($reffed_state)"/>
                         <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                        <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#panos') and ($state_name='config_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                        <sch:assert test="(($state_namespace='urn:oval:v6:definitions:panos') and ($state_name='config_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                     </sch:rule>
                 </sch:pattern>
             </xsd:appinfo>

--- a/oval-schemas/panos-system-characteristics-schema.xsd
+++ b/oval-schemas/panos-system-characteristics-schema.xsd
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-            xmlns:oval-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5"
-            xmlns:panos-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#panos"
+            xmlns:oval-sc="urn:oval:v6:system-characteristics"
+            xmlns:panos-sc="urn:oval:v6:system-characteristics:panos"
             xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-            targetNamespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#panos"
-            elementFormDefault="qualified" version="5.12">
-    <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5" schemaLocation="oval-system-characteristics-schema.xsd"/>
+            targetNamespace="urn:oval:v6:system-characteristics:panos"
+            elementFormDefault="qualified" version="6.0">
+    <xsd:import namespace="urn:oval:v6:system-characteristics" schemaLocation="oval-system-characteristics-schema.xsd"/>
     <xsd:annotation>
         <xsd:documentation>
             This document outlines the items of the OVAL System Characteristics XML schema that are composed of Palo Alto-specific 
@@ -19,8 +19,8 @@
         </xsd:documentation>
         <xsd:appinfo>
             <schema>Palo Alto (PAN-OS) Definitions</schema>
-            <version>5.12</version>
-            <date>11/29/2024 09:00:00 AM</date>
+            <version>6.0</version>
+            <date>1/1/2025 09:00:00 AM</date>
             <terms_of_use>
                 For the portion subject to the copyright in the United States: Copyright (c) 2016 United States Government. 
                 All rights reserved. Copyright (c) 2016, Center for Internet Security. All rights reserved. The contents of 
@@ -28,8 +28,8 @@
                 OVAL License for the specific language governing permissions and limitations for use of this schema. When 
                 distributing copies of the OVAL Schema, this license header must be included.
             </terms_of_use>
-            <sch:ns prefix="oval-sc" uri="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5"/>
-            <sch:ns prefix="panos-sc" uri="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#panos"/>
+            <sch:ns prefix="oval-sc" urn="urn:oval:v6:system-characteristics"/>
+            <sch:ns prefix="panos-sc" urn="urn:oval:v6:system-characteristics:panos"/>
             <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
         </xsd:appinfo>
     </xsd:annotation>

--- a/oval-schemas/pixos-definitions-schema.xsd
+++ b/oval-schemas/pixos-definitions-schema.xsd
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-            xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5"
-            xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5"
-            xmlns:pixos-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#pixos"
+            xmlns:oval="urn:oval:v6:common"
+            xmlns:oval-def="urn:oval:v6:definitions"
+            xmlns:pixos-def="urn:oval:v6:definitions:pixos"
             xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-            targetNamespace="http://oval.mitre.org/XMLSchema/oval-definitions-5#pixos"
-            elementFormDefault="qualified" version="5.12">
-      <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-common-5" schemaLocation="oval-common-schema.xsd"/>
-      <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-definitions-5" schemaLocation="oval-definitions-schema.xsd"/>
+            targetNamespace="urn:oval:v6:definitions:pixos"
+            elementFormDefault="qualified" version="6.0">
+      <xsd:import namespace="urn:oval:v6:common" schemaLocation="oval-common-schema.xsd"/>
+      <xsd:import namespace="urn:oval:v6:definitions" schemaLocation="oval-definitions-schema.xsd"/>
       <xsd:annotation>
             <xsd:documentation>The following is a description of the elements, types, and attributes that compose the PIX specific tests found in Open Vulnerability and Assessment Language (OVAL). Each test is an extension of the standard test element defined in the Core Definition Schema. Through extension, each test inherits a set of elements and attributes that are shared amongst all OVAL tests. Each test is described in detail and should provide the information necessary to understand what each element and attribute represents. This document is intended for developers and assumes some familiarity with XML. A high level description of the interaction between the different tests and their relationship to the Core Definition Schema is not outlined here.</xsd:documentation>
             <xsd:documentation>This schema was originally developed by Yuzheng Zhou and Eric Grey at Hewlett-Packard. The OVAL Schema is maintained by the OVAL Community. For more information, including how to get involved in the project and how to submit change requests, please visit the OVAL website at https://github.com/OVAL-Community/.</xsd:documentation>
             <xsd:appinfo>
                   <schema>PixOS Definition</schema>
-                  <version>5.12</version>
-                  <date>11/29/2024 09:00:00 AM</date>
+                  <version>6.0</version>
+                  <date>1/1/2025 09:00:00 AM</date>
                   <terms_of_use>This software is an open standard developed by multiple parties, including the United States Government (Government). The Government hereby grants you a non-exclusive, royalty-free, worldwide license to use, modify, and/or reproduce the software for any lawful purpose provided that you reproduce this License/Disclaimer language with any use/modification/copy of the software. The Government assumes no responsibility whatsoever for this software's use by other parties, and the software is provided "AS IS" without warranty or guarantee of any kind, express or implied, including, but not limited to, the warranties of merchantability, fitness for a particular purpose, and noninfringement. In no event shall the Government be liable for any claim, damages or other liability, whether in an action of contract, tort or other dealings in the software. The Government has no obligation hereunder to provide maintenance, support, updates, enhancements, or modifications to the software. Users may submit proposals and/or updates regarding the software, which proposals and/or updates the Government, at its sole discretion, can choose to incorporate into the software. Proposals and/or updates submitted to the Government by users must be accompanied by a license to such proposals and/or updates that is no more restrictive than this License/Disclaimer.</terms_of_use>
-                  <sch:ns prefix="oval-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5"/>
-                  <sch:ns prefix="pixos-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5#pixos"/>
+                  <sch:ns prefix="oval-def" urn="urn:oval:v6:definitions"/>
+                  <sch:ns prefix="pixos-def" urn="urn:oval:v6:definitions:pixos"/>
                   <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
             </xsd:appinfo>
       </xsd:annotation>
@@ -32,7 +32,7 @@
                               <oval:test>line_test</oval:test>
                               <oval:object>line_object</oval:object>
                               <oval:state>line_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#pixos">line_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:pixos">line_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -76,7 +76,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#pixos') and ($state_name='line_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:pixos') and ($state_name='line_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -135,7 +135,7 @@
                               <oval:test>version_test</oval:test>
                               <oval:object>version_object</oval:object>
                               <oval:state>version_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#pixos">version_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:pixos">version_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>

--- a/oval-schemas/pixos-system-characteristics-schema.xsd
+++ b/oval-schemas/pixos-system-characteristics-schema.xsd
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-            xmlns:oval-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5"
-            xmlns:pixos-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#pixos"
+            xmlns:oval-sc="urn:oval:v6:system-characteristics"
+            xmlns:pixos-sc="urn:oval:v6:system-characteristics:pixos"
             xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-            targetNamespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#pixos"
-            elementFormDefault="qualified" version="5.12">
-     <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5" schemaLocation="oval-system-characteristics-schema.xsd"/>
+            targetNamespace="urn:oval:v6:system-characteristics:pixos"
+            elementFormDefault="qualified" version="6.0">
+     <xsd:import namespace="urn:oval:v6:system-characteristics" schemaLocation="oval-system-characteristics-schema.xsd"/>
      <xsd:annotation>
           <xsd:documentation>The following is a description of the elements, types, and attributes that compose the Cisco PIX (Private Internet Exchange)  specific system characteristic items found in Open Vulnerability and Assessment Language (OVAL). Each item is an extension of the standard test element defined in the Core Definition Schema. Through extension, each test inherits a set of elements and attributes that are shared amongst all OVAL tests. Each test is described in detail and should provide the information necessary to understand what each element and attribute represents. This document is intended for developers and assumes some familiarity with XML. A high level description of the interaction between the different tests and their relationship to the Core Definition Schema is not outlined here.</xsd:documentation>
           <xsd:documentation>This schema was originally developed by Yuzheng Zhou and Eric Grey at Hewlett-Packard. The OVAL Schema is maintained by the OVAL Community. For more information, including how to get involved in the project and how to submit change requests, please visit the OVAL website at https://github.com/OVAL-Community/.</xsd:documentation>
           <xsd:appinfo>
                <schema>PixOS System Characteristics</schema>
-               <version>5.12</version>
-               <date>11/29/2024 09:00:00 AM</date>
+               <version>6.0</version>
+               <date>1/1/2025 09:00:00 AM</date>
                 <terms_of_use>This software is an open standard developed by multiple parties, including the United States Government (Government). The Government hereby grants you a non-exclusive, royalty-free, worldwide license to use, modify, and/or reproduce the software for any lawful purpose provided that you reproduce this License/Disclaimer language with any use/modification/copy of the software. The Government assumes no responsibility whatsoever for this software's use by other parties, and the software is provided "AS IS" without warranty or guarantee of any kind, express or implied, including, but not limited to, the warranties of merchantability, fitness for a particular purpose, and noninfringement. In no event shall the Government be liable for any claim, damages or other liability, whether in an action of contract, tort or other dealings in the software. The Government has no obligation hereunder to provide maintenance, support, updates, enhancements, or modifications to the software. Users may submit proposals and/or updates regarding the software, which proposals and/or updates the Government, at its sole discretion, can choose to incorporate into the software. Proposals and/or updates submitted to the Government by users must be accompanied by a license to such proposals and/or updates that is no more restrictive than this License/Disclaimer.</terms_of_use>
-               <sch:ns prefix="oval-sc" uri="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5"/>
-               <sch:ns prefix="pixos-sc" uri="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#pixos"/>
+               <sch:ns prefix="oval-sc" urn="urn:oval:v6:system-characteristics"/>
+               <sch:ns prefix="pixos-sc" urn="urn:oval:v6:system-characteristics:pixos"/>
               <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
           </xsd:appinfo>
      </xsd:annotation>

--- a/oval-schemas/sharepoint-definitions-schema.xsd
+++ b/oval-schemas/sharepoint-definitions-schema.xsd
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-            xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5"
-            xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5"
-            xmlns:sp-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#sharepoint"
+            xmlns:oval="urn:oval:v6:common"
+            xmlns:oval-def="urn:oval:v6:definitions"
+            xmlns:sp-def="urn:oval:v6:definitions:sharepoint"
             xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-            targetNamespace="http://oval.mitre.org/XMLSchema/oval-definitions-5#sharepoint"
-            elementFormDefault="qualified" version="5.12">
-      <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-definitions-5" schemaLocation="oval-definitions-schema.xsd"/>
+            targetNamespace="urn:oval:v6:definitions:sharepoint"
+            elementFormDefault="qualified" version="6.0">
+      <xsd:import namespace="urn:oval:v6:definitions" schemaLocation="oval-definitions-schema.xsd"/>
       <xsd:annotation>
             <xsd:documentation>The following is a description of the elements, types, and attributes that compose the SharePoint specific tests found in Open Vulnerability and Assessment Language (OVAL). Each test is an extension of the standard test element defined in the Core Definition Schema. Through extension, each test inherits a set of elements and attributes that are shared amongst all
                   OVAL tests. Each test is described in detail and should provide the information necessary to understand what each element and attribute represents. This document is intended for developers and assumes some familiarity with XML. A high level description of the interaction between the different tests and their relationship to the Core Definition Schema is not outlined
@@ -15,11 +15,11 @@
             <xsd:documentation>The OVAL Schema is maintained by the OVAL Community. For more information, including how to get involved in the project and how to submit change requests, please visit the OVAL website at https://github.com/OVAL-Community/.</xsd:documentation>
             <xsd:appinfo>
                   <schema>SharePoint Definition</schema>
-                  <version>5.12</version>
-                  <date>11/29/2024 09:00:00 AM</date>
+                  <version>6.0</version>
+                  <date>1/1/2025 09:00:00 AM</date>
                   <terms_of_use>This software is an open standard developed by multiple parties, including the United States Government (Government). The Government hereby grants you a non-exclusive, royalty-free, worldwide license to use, modify, and/or reproduce the software for any lawful purpose provided that you reproduce this License/Disclaimer language with any use/modification/copy of the software. The Government assumes no responsibility whatsoever for this software's use by other parties, and the software is provided "AS IS" without warranty or guarantee of any kind, express or implied, including, but not limited to, the warranties of merchantability, fitness for a particular purpose, and noninfringement. In no event shall the Government be liable for any claim, damages or other liability, whether in an action of contract, tort or other dealings in the software. The Government has no obligation hereunder to provide maintenance, support, updates, enhancements, or modifications to the software. Users may submit proposals and/or updates regarding the software, which proposals and/or updates the Government, at its sole discretion, can choose to incorporate into the software. Proposals and/or updates submitted to the Government by users must be accompanied by a license to such proposals and/or updates that is no more restrictive than this License/Disclaimer.</terms_of_use>
-                  <sch:ns prefix="oval-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5"/>
-                  <sch:ns prefix="sp-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5#sharepoint"/>
+                  <sch:ns prefix="oval-def" urn="urn:oval:v6:definitions"/>
+                  <sch:ns prefix="sp-def" urn="urn:oval:v6:definitions:sharepoint"/>
                   <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
             </xsd:appinfo>
       </xsd:annotation>
@@ -35,7 +35,7 @@
                               <oval:test>spwebapplication_test</oval:test>
                               <oval:object>spwebapplication_object</oval:object>
                               <oval:state>spwebapplication_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#sharepoint">spwebapplication_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:sharepoint">spwebapplication_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -80,7 +80,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#sharepoint') and ($state_name='spwebapplication_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:sharepoint') and ($state_name='spwebapplication_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -390,7 +390,7 @@
                               <oval:test>spgroup_test</oval:test>
                               <oval:object>spgroup_object</oval:object>
                               <oval:state>spgroup_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#sharepoint">spgroup_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:sharepoint">spgroup_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -435,7 +435,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#sharepoint') and ($state_name='spgroup_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:sharepoint') and ($state_name='spgroup_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -509,7 +509,7 @@
                               <oval:test>spweb_test</oval:test>
                               <oval:object>spweb_object</oval:object>
                               <oval:state>spweb_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#sharepoint">spweb_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:sharepoint">spweb_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -554,7 +554,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#sharepoint') and ($state_name='spweb_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:sharepoint') and ($state_name='spweb_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -634,7 +634,7 @@
                               <oval:test>splist_test</oval:test>
                               <oval:object>splist_object</oval:object>
                               <oval:state>splist_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#sharepoint">splist_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:sharepoint">splist_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -679,7 +679,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#sharepoint') and ($state_name='splist_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:sharepoint') and ($state_name='splist_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -748,7 +748,7 @@
                               <oval:test>spantivirussettings_test</oval:test>
                               <oval:object>spantivirussettings_object</oval:object>
                               <oval:state>spantivirussettings_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#sharepoint">spantivirussettings_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:sharepoint">spantivirussettings_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -794,7 +794,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#sharepoint') and ($state_name='spantivirussettings_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:sharepoint') and ($state_name='spantivirussettings_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -899,7 +899,7 @@
                               <oval:test>spsiteadministration_test</oval:test>
                               <oval:object>spsiteadministration_object</oval:object>
                               <oval:state>spsiteadministration_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#sharepoint">spsiteadministration_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:sharepoint">spsiteadministration_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -944,7 +944,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#sharepoint') and ($state_name='spsiteadministration_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:sharepoint') and ($state_name='spsiteadministration_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -1008,7 +1008,7 @@
                               <oval:test>spsite_test</oval:test>
                               <oval:object>spsite_object</oval:object>
                               <oval:state>spsite_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#sharepoint">spsite_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:sharepoint">spsite_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -1053,7 +1053,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#sharepoint') and ($state_name='spsite_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:sharepoint') and ($state_name='spsite_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -1129,7 +1129,7 @@
                               <oval:test>spcrawlrule_test</oval:test>
                               <oval:object>spcrawlrule_object</oval:object>
                               <oval:state>spcrawlrule_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#sharepoint">spcrawlrule_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:sharepoint">spcrawlrule_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -1173,7 +1173,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#sharepoint') and ($state_name='spcrawlrule_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:sharepoint') and ($state_name='spcrawlrule_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -1262,7 +1262,7 @@
                               <oval:test>spjobdefinition_test</oval:test>
                               <oval:object>spjobdefinition_object</oval:object>
                               <oval:state>spjobdefinition_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#sharepoint">spjobdefinition_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:sharepoint">spjobdefinition_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -1330,7 +1330,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#sharepoint') and ($state_name='spjobdefinition_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:sharepoint') and ($state_name='spjobdefinition_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -1416,7 +1416,7 @@
                               <oval:test>spjobdefinition510_test</oval:test>
                               <oval:object>spjobdefinition510_object</oval:object>
                               <oval:state>spjobdefinition510_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#sharepoint">spjobdefinition510_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:sharepoint">spjobdefinition510_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -1460,7 +1460,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#sharepoint') and ($state_name='spjobdefinition510_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:sharepoint') and ($state_name='spjobdefinition510_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -1539,7 +1539,7 @@
                               <oval:test>bestbet_test</oval:test>
                               <oval:object>bestbet_object</oval:object>
                               <oval:state>bestbet_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#sharepoint">bestbet_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:sharepoint">bestbet_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -1584,7 +1584,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#sharepoint') and ($state_name='bestbet_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:sharepoint') and ($state_name='bestbet_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -1658,7 +1658,7 @@
                               <oval:test>infopolicycoll_test</oval:test>
                               <oval:object>infopolicycoll_object</oval:object>
                               <oval:state>infopolicycoll_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#sharepoint">infopolicycoll_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:sharepoint">infopolicycoll_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -1703,7 +1703,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#sharepoint') and ($state_name='infopolicycoll_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:sharepoint') and ($state_name='infopolicycoll_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -1782,7 +1782,7 @@
                               <oval:test>spdiagnosticsservice_test</oval:test>
                               <oval:object>spdiagnosticsservice_object</oval:object>
                               <oval:state>spdiagnosticsservice_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#sharepoint">spdiagnosticsservice_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:sharepoint">spdiagnosticsservice_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -1827,7 +1827,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#sharepoint') and ($state_name='spdiagnosticsservice_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:sharepoint') and ($state_name='spdiagnosticsservice_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -1911,7 +1911,7 @@
                               <oval:test>spdiagnosticslevel_test</oval:test>
                               <oval:object>spdiagnosticslevel_object</oval:object>
                               <oval:state>spdiagnosticslevel_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#sharepoint">spdiagnosticslevel_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:sharepoint">spdiagnosticslevel_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -1955,7 +1955,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#sharepoint') and ($state_name='spdiagnosticslevel_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:sharepoint') and ($state_name='spdiagnosticslevel_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -2034,7 +2034,7 @@
                               <oval:test>sppolicyfeature_test</oval:test>
                               <oval:object>sppolicyfeature_object</oval:object>
                               <oval:state>sppolicyfeature_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#sharepoint">sppolicyfeature_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:sharepoint">sppolicyfeature_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -2079,7 +2079,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#sharepoint') and ($state_name='sppolicyfeature_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:sharepoint') and ($state_name='sppolicyfeature_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -2178,7 +2178,7 @@
                               <oval:test>sppolicy_test</oval:test>
                               <oval:object>sppolicy_object</oval:object>
                               <oval:state>sppolicy_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#sharepoint">sppolicy_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:sharepoint">sppolicy_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>

--- a/oval-schemas/sharepoint-system-characteristics-schema.xsd
+++ b/oval-schemas/sharepoint-system-characteristics-schema.xsd
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-            xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5"
-            xmlns:oval-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5"
-            xmlns:sp-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#sharepoint"
+            xmlns:oval="urn:oval:v6:common"
+            xmlns:oval-sc="urn:oval:v6:system-characteristics"
+            xmlns:sp-sc="urn:oval:v6:system-characteristics:sharepoint"
             xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-            targetNamespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#sharepoint"
-            elementFormDefault="qualified" version="5.12">
-      <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5" schemaLocation="oval-system-characteristics-schema.xsd"/>
+            targetNamespace="urn:oval:v6:system-characteristics:sharepoint"
+            elementFormDefault="qualified" version="6.0">
+      <xsd:import namespace="urn:oval:v6:system-characteristics" schemaLocation="oval-system-characteristics-schema.xsd"/>
       <xsd:annotation>
             <xsd:documentation>The following is a description of the elements, types, and attributes that compose the SharePoint specific system characteristic items found in Open Vulnerability and Assessment Language (OVAL). Each item is an extension of the standard item element defined in the Core System Characteristic Schema. Through extension, each item inherits a set of elements and attributes that are shared amongst all OVAL Items. Each item is described in detail and should provide the information necessary to understand what each element and attribute represents. This document is intended for developers and assumes some familiarity with XML. A high level description of the interaction between the different tests and their relationship to the Core System Characteristic Schema is not outlined here.</xsd:documentation>
             <xsd:documentation>The SharePoint Component Schema is based on the SharePoint Object Model (Windows SharePoint Services 3.0)</xsd:documentation>
             <xsd:documentation>The OVAL Schema is maintained by the OVAL Community. For more information, including how to get involved in the project and how to submit change requests, please visit the OVAL website at https://github.com/OVAL-Community/.</xsd:documentation>
             <xsd:appinfo>
                   <schema>SharePoint System Characteristics</schema>
-                  <version>5.12</version>
-                  <date>11/29/2024 09:00:00 AM</date>
+                  <version>6.0</version>
+                  <date>1/1/2025 09:00:00 AM</date>
                   <terms_of_use>This software is an open standard developed by multiple parties, including the United States Government (Government). The Government hereby grants you a non-exclusive, royalty-free, worldwide license to use, modify, and/or reproduce the software for any lawful purpose provided that you reproduce this License/Disclaimer language with any use/modification/copy of the software. The Government assumes no responsibility whatsoever for this software's use by other parties, and the software is provided "AS IS" without warranty or guarantee of any kind, express or implied, including, but not limited to, the warranties of merchantability, fitness for a particular purpose, and noninfringement. In no event shall the Government be liable for any claim, damages or other liability, whether in an action of contract, tort or other dealings in the software. The Government has no obligation hereunder to provide maintenance, support, updates, enhancements, or modifications to the software. Users may submit proposals and/or updates regarding the software, which proposals and/or updates the Government, at its sole discretion, can choose to incorporate into the software. Proposals and/or updates submitted to the Government by users must be accompanied by a license to such proposals and/or updates that is no more restrictive than this License/Disclaimer.</terms_of_use>
-                  <sch:ns prefix="oval-sc" uri="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5"/>
-                  <sch:ns prefix="sp-sc" uri="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#sharepoint"/>
+                  <sch:ns prefix="oval-sc" urn="urn:oval:v6:system-characteristics"/>
+                  <sch:ns prefix="sp-sc" urn="urn:oval:v6:system-characteristics:sharepoint"/>
                   <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
             </xsd:appinfo>
       </xsd:annotation>

--- a/oval-schemas/solaris-definitions-schema.xsd
+++ b/oval-schemas/solaris-definitions-schema.xsd
@@ -1,22 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-            xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5"
-            xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5"
-            xmlns:sol-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#solaris"
+            xmlns:oval-def="urn:oval:v6:definitions"
+            xmlns:oval="urn:oval:v6:common"
+            xmlns:sol-def="urn:oval:v6:definitions:solaris"
             xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-            targetNamespace="http://oval.mitre.org/XMLSchema/oval-definitions-5#solaris"
-            elementFormDefault="qualified" version="5.12">
-      <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-definitions-5" schemaLocation="oval-definitions-schema.xsd"/>
+            targetNamespace="urn:oval:v6:definitions:solaris"
+            elementFormDefault="qualified" version="6.0">
+      <xsd:import namespace="urn:oval:v6:definitions" schemaLocation="oval-definitions-schema.xsd"/>
       <xsd:annotation>
             <xsd:documentation>The following is a description of the elements, types, and attributes that compose the Solaris specific tests found in Open Vulnerability and Assessment Language (OVAL). Each test is an extension of the standard test element defined in the Core Definition Schema. Through extension, each test inherits a set of elements and attributes that are shared amongst all OVAL tests. Each test is described in detail and should provide the information necessary to understand what each element and attribute represents. This document is intended for developers and assumes some familiarity with XML. A high level description of the interaction between the different tests and their relationship to the Core Definition Schema is not outlined here.</xsd:documentation>
             <xsd:documentation>The OVAL Schema is maintained by the OVAL Community. For more information, including how to get involved in the project and how to submit change requests, please visit the OVAL website at https://github.com/OVAL-Community/.</xsd:documentation>
             <xsd:appinfo>
                   <schema>Solaris Definition</schema>
-                  <version>5.12</version>
-                  <date>11/29/2024 09:00:00 AM</date>
+                  <version>6.0</version>
+                  <date>1/1/2025 09:00:00 AM</date>
                   <terms_of_use>This software is an open standard developed by multiple parties, including the United States Government (Government). The Government hereby grants you a non-exclusive, royalty-free, worldwide license to use, modify, and/or reproduce the software for any lawful purpose provided that you reproduce this License/Disclaimer language with any use/modification/copy of the software. The Government assumes no responsibility whatsoever for this software's use by other parties, and the software is provided "AS IS" without warranty or guarantee of any kind, express or implied, including, but not limited to, the warranties of merchantability, fitness for a particular purpose, and noninfringement. In no event shall the Government be liable for any claim, damages or other liability, whether in an action of contract, tort or other dealings in the software. The Government has no obligation hereunder to provide maintenance, support, updates, enhancements, or modifications to the software. Users may submit proposals and/or updates regarding the software, which proposals and/or updates the Government, at its sole discretion, can choose to incorporate into the software. Proposals and/or updates submitted to the Government by users must be accompanied by a license to such proposals and/or updates that is no more restrictive than this License/Disclaimer.</terms_of_use>
-                  <sch:ns prefix="oval-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5"/>
-                  <sch:ns prefix="sol-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5#solaris"/>
+                  <sch:ns prefix="oval-def" urn="urn:oval:v6:definitions"/>
+                  <sch:ns prefix="sol-def" urn="urn:oval:v6:definitions:solaris"/>
                   <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
             </xsd:appinfo>
       </xsd:annotation>
@@ -31,7 +31,7 @@
                               <oval:test>facet_test</oval:test>
                               <oval:object>facet_object</oval:object>
                               <oval:state>facet_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#solaris">facet_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:solaris">facet_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -74,7 +74,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#solaris') and ($state_name='facet_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:solaris') and ($state_name='facet_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -143,7 +143,7 @@
                               <oval:test>image_test</oval:test>
                               <oval:object>image_object</oval:object>
                               <oval:state>image_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#solaris">image_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:solaris">image_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -186,7 +186,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#solaris') and ($state_name='image_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:solaris') and ($state_name='image_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -256,7 +256,7 @@
                               <oval:test>isainfo_test</oval:test>
                               <oval:object>isainfo_object</oval:object>
                               <oval:state>isainfo_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#solaris">isainfo_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:solaris">isainfo_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -338,7 +338,7 @@
                               <oval:test>ndd_test</oval:test>
                               <oval:object>ndd_object</oval:object>
                               <oval:state>ndd_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#solaris">ndd_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:solaris">ndd_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -381,7 +381,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#solaris') and ($state_name='ndd_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:solaris') and ($state_name='ndd_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -455,7 +455,7 @@
                               <oval:test>package_test</oval:test>
                               <oval:object>package_object</oval:object>
                               <oval:state>package_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#solaris">package_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:solaris">package_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -501,7 +501,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#solaris') and ($state_name='package_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:solaris') and ($state_name='package_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -580,7 +580,7 @@
                               <oval:test>package511_test</oval:test>
                               <oval:object>package511_object</oval:object>
                               <oval:state>package511_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#solaris">package511_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:solaris">package511_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -623,7 +623,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#solaris') and ($state_name='package511_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:solaris') and ($state_name='package511_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -732,7 +732,7 @@
                               <oval:test>packageavoidlist_test</oval:test>
                               <oval:object>packageavoidlist_object</oval:object>
                               <oval:state>packageavoidlist_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#solaris">packageavoidlist_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:solaris">packageavoidlist_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -775,7 +775,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#solaris') and ($state_name='packageavoidlist_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:solaris') and ($state_name='packageavoidlist_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -815,7 +815,7 @@
                               <oval:test>packagecheck_test</oval:test>
                               <oval:object>packagecheck_object</oval:object>
                               <oval:state>packagecheck_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#solaris">packagecheck_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:solaris">packagecheck_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -860,7 +860,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#solaris') and ($state_name='packagecheck_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:solaris') and ($state_name='packagecheck_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -1005,7 +1005,7 @@
                               <oval:test>packagefreezelist_test</oval:test>
                               <oval:object>packagefreezelist_object</oval:object>
                               <oval:state>packagefreezelist_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#solaris">packagefreezelist_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:solaris">packagefreezelist_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -1048,7 +1048,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#solaris') and ($state_name='packagefreezelist_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:solaris') and ($state_name='packagefreezelist_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -1088,7 +1088,7 @@
                               <oval:test>packagepublisher_test</oval:test>
                               <oval:object>packagepublisher_object</oval:object>
                               <oval:state>packagepublisher_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#solaris">packagepublisher_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:solaris">packagepublisher_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -1131,7 +1131,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#solaris') and ($state_name='packagepublisher_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:solaris') and ($state_name='packagepublisher_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -1245,7 +1245,7 @@
                               <oval:test>patch54_test</oval:test>
                               <oval:object>patch54_object</oval:object>
                               <oval:state>patch_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#solaris">patch_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:solaris">patch_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -1286,7 +1286,7 @@
                               <oval:test>patch_test</oval:test>
                               <oval:object>patch_object</oval:object>
                               <oval:state>patch_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#solaris">patch_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:solaris">patch_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -1344,7 +1344,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#solaris') and ($state_name='patch_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:solaris') and ($state_name='patch_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -1456,7 +1456,7 @@
                               <oval:test>smf_test</oval:test>
                               <oval:object>smf_object</oval:object>
                               <oval:state>smf_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#solaris">smf_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:solaris">smf_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -1496,7 +1496,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#solaris') and ($state_name='smf_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:solaris') and ($state_name='smf_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -1580,7 +1580,7 @@
                               <oval:test>smfproperty_test</oval:test>
                               <oval:object>smfproperty_object</oval:object>
                               <oval:state>smfproperty_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#solaris">smfproperty_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:solaris">smfproperty_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -1617,7 +1617,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#solaris') and ($state_name='smfproperty_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:solaris') and ($state_name='smfproperty_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -1701,7 +1701,7 @@
                               <oval:test>variant_test</oval:test>
                               <oval:object>variant_object</oval:object>
                               <oval:state>variant_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#solaris">variant_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:solaris">variant_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -1744,7 +1744,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#solaris') and ($state_name='variant_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:solaris') and ($state_name='variant_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -1813,7 +1813,7 @@
                               <oval:test>virtualizationinfo_test</oval:test>
                               <oval:object>virtualizationinfo_object</oval:object>
                               <oval:state>virtualizationinfo_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#solaris">virtualizationinfo_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:solaris">virtualizationinfo_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -1856,7 +1856,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#solaris') and ($state_name='virtualizationinfo_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:solaris') and ($state_name='virtualizationinfo_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>

--- a/oval-schemas/solaris-system-characteristics-schema.xsd
+++ b/oval-schemas/solaris-system-characteristics-schema.xsd
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-            xmlns:oval-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5"
-            xmlns:sol-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#solaris"
+            xmlns:oval-sc="urn:oval:v6:system-characteristics"
+            xmlns:sol-sc="urn:oval:v6:system-characteristics:solaris"
             xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-            targetNamespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#solaris"
-            elementFormDefault="qualified" version="5.12">
-     <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5" schemaLocation="oval-system-characteristics-schema.xsd"/>
+            targetNamespace="urn:oval:v6:system-characteristics:solaris"
+            elementFormDefault="qualified" version="6.0">
+     <xsd:import namespace="urn:oval:v6:system-characteristics" schemaLocation="oval-system-characteristics-schema.xsd"/>
      <xsd:annotation>
           <xsd:documentation>The following is a description of the elements, types, and attributes that compose the Solaris specific system characteristic items found in Open Vulnerability and Assessment Language (OVAL). Each item is an extension of the standard test element defined in the Core Definition Schema. Through extension, each test inherits a set of elements and attributes that are shared amongst all OVAL tests. Each test is described in detail and should provide the information necessary to understand what each element and attribute represents. This document is intended for developers and assumes some familiarity with XML. A high level description of the interaction between the different tests and their relationship to the Core Definition Schema is not outlined here.</xsd:documentation>
           <xsd:documentation>The OVAL Schema is maintained by the OVAL Community. For more information, including how to get involved in the project and how to submit change requests, please visit the OVAL website at https://github.com/OVAL-Community/.</xsd:documentation>
           <xsd:appinfo>
                <schema>Solaris System Characteristics</schema>
-               <version>5.12</version>
-               <date>11/29/2024 09:00:00 AM</date>
+               <version>6.0</version>
+               <date>1/1/2025 09:00:00 AM</date>
                 <terms_of_use>This software is an open standard developed by multiple parties, including the United States Government (Government). The Government hereby grants you a non-exclusive, royalty-free, worldwide license to use, modify, and/or reproduce the software for any lawful purpose provided that you reproduce this License/Disclaimer language with any use/modification/copy of the software. The Government assumes no responsibility whatsoever for this software's use by other parties, and the software is provided "AS IS" without warranty or guarantee of any kind, express or implied, including, but not limited to, the warranties of merchantability, fitness for a particular purpose, and noninfringement. In no event shall the Government be liable for any claim, damages or other liability, whether in an action of contract, tort or other dealings in the software. The Government has no obligation hereunder to provide maintenance, support, updates, enhancements, or modifications to the software. Users may submit proposals and/or updates regarding the software, which proposals and/or updates the Government, at its sole discretion, can choose to incorporate into the software. Proposals and/or updates submitted to the Government by users must be accompanied by a license to such proposals and/or updates that is no more restrictive than this License/Disclaimer.</terms_of_use>
-               <sch:ns prefix="oval-sc" uri="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5"/>
-               <sch:ns prefix="sol-sc" uri="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#solaris"/>
+               <sch:ns prefix="oval-sc" urn="urn:oval:v6:system-characteristics"/>
+               <sch:ns prefix="sol-sc" urn="urn:oval:v6:system-characteristics:solaris"/>
               <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
           </xsd:appinfo>
      </xsd:annotation>

--- a/oval-schemas/unix-definitions-schema.xsd
+++ b/oval-schemas/unix-definitions-schema.xsd
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-            xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5"
-            xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5"
-            xmlns:unix-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix"
+            xmlns:oval-def="urn:oval:v6:definitions"
+            xmlns:oval="urn:oval:v6:common"
+            xmlns:unix-def="urn:oval:v6:definitions:unix"
             xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-            targetNamespace="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix"
-            elementFormDefault="qualified" version="5.12">
-      <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-definitions-5" schemaLocation="oval-definitions-schema.xsd"/>
-      <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-common-5" schemaLocation="oval-common-schema.xsd"/>
+            targetNamespace="urn:oval:v6:definitions:unix"
+            elementFormDefault="qualified" version="6.0">
+      <xsd:import namespace="urn:oval:v6:definitions" schemaLocation="oval-definitions-schema.xsd"/>
+      <xsd:import namespace="urn:oval:v6:common" schemaLocation="oval-common-schema.xsd"/>
       <xsd:annotation>
             <xsd:documentation>The following is a description of the elements, types, and attributes that compose generic UNIX tests found in Open Vulnerability and Assessment Language (OVAL). Each test is an extension of the standard test element defined in the Core Definition Schema. Through extension, each test inherits a set of elements and attributes that are shared amongst all OVAL tests. Each test is described in detail and should provide the information necessary to understand what each element and attribute represents. This document is intended for developers and assumes some familiarity with XML. A high level description of the interaction between the different tests and their relationship to the Core Definition Schema is not outlined here.</xsd:documentation>
             <xsd:documentation>The OVAL Schema is maintained by the OVAL Community. For more information, including how to get involved in the project and how to submit change requests, please visit the OVAL website at https://github.com/OVAL-Community/.</xsd:documentation>
             <xsd:appinfo>
                   <schema>UNIX Definition</schema>
-                  <version>5.12</version>
-                  <date>11/29/2024 09:00:00 AM</date>
+                  <version>6.0</version>
+                  <date>1/1/2025 09:00:00 AM</date>
                   <terms_of_use>This software is an open standard developed by multiple parties, including the United States Government (Government). The Government hereby grants you a non-exclusive, royalty-free, worldwide license to use, modify, and/or reproduce the software for any lawful purpose provided that you reproduce this License/Disclaimer language with any use/modification/copy of the software. The Government assumes no responsibility whatsoever for this software's use by other parties, and the software is provided "AS IS" without warranty or guarantee of any kind, express or implied, including, but not limited to, the warranties of merchantability, fitness for a particular purpose, and noninfringement. In no event shall the Government be liable for any claim, damages or other liability, whether in an action of contract, tort or other dealings in the software. The Government has no obligation hereunder to provide maintenance, support, updates, enhancements, or modifications to the software. Users may submit proposals and/or updates regarding the software, which proposals and/or updates the Government, at its sole discretion, can choose to incorporate into the software. Proposals and/or updates submitted to the Government by users must be accompanied by a license to such proposals and/or updates that is no more restrictive than this License/Disclaimer.</terms_of_use>
-                  <sch:ns prefix="oval-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5"/>
-                  <sch:ns prefix="unix-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix"/>
+                  <sch:ns prefix="oval-def" urn="urn:oval:v6:definitions"/>
+                  <sch:ns prefix="unix-def" urn="urn:oval:v6:definitions:unix"/>
                   <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
             </xsd:appinfo>
       </xsd:annotation>
@@ -32,7 +32,7 @@
                               <oval:test>dnscache_test</oval:test>
                               <oval:object>dnscache_object</oval:object>
                               <oval:state>dnscache_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#unix">dnscache_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:unix">dnscache_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -75,7 +75,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#unix') and ($state_name='dnscache_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:unix') and ($state_name='dnscache_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -139,7 +139,7 @@
                               <oval:test>file_test</oval:test>
                               <oval:object>file_object</oval:object>
                               <oval:state>file_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#unix">file_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:unix">file_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -179,7 +179,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#unix') and ($state_name='file_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:unix') and ($state_name='file_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -572,7 +572,7 @@
                               <oval:test>fileextendedattribute_test</oval:test>
                               <oval:object>fileextendedattribute_object</oval:object>
                               <oval:state>fileextendedattribute_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#unix">fileextendedattribute_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:unix">fileextendedattribute_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -618,7 +618,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#unix') and ($state_name='fileextendedattribute_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:unix') and ($state_name='fileextendedattribute_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -741,7 +741,7 @@
                               <oval:test>gconf_test</oval:test>
                               <oval:object>gconf_object</oval:object>
                               <oval:state>gconf_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#unix">gconf_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:unix">gconf_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -784,7 +784,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#unix') and ($state_name='gconf_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:unix') and ($state_name='gconf_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -887,7 +887,7 @@
                               <oval:test>inetd_test</oval:test>
                               <oval:object>inetd_object</oval:object>
                               <oval:state>inetd_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#unix">inetd_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:unix">inetd_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -931,7 +931,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#unix') and ($state_name='inetd_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:unix') and ($state_name='inetd_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -1020,7 +1020,7 @@
                               <oval:test>interface_test</oval:test>
                               <oval:object>interface_object</oval:object>
                               <oval:state>interface_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#unix">interface_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:unix">interface_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -1058,7 +1058,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#unix') and ($state_name='interface_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:unix') and ($state_name='interface_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -1143,7 +1143,7 @@
                               <oval:test>password_test</oval:test>
                               <oval:object>password_object</oval:object>
                               <oval:state>password_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#unix">password_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:unix">password_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -1181,7 +1181,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#unix') and ($state_name='password_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:unix') and ($state_name='password_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -1299,7 +1299,7 @@
                               <oval:test>process_test</oval:test>
                               <oval:object>process_object</oval:object>
                               <oval:state>process_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#unix">process_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:unix">process_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -1453,7 +1453,7 @@
                               <oval:test>process58_test</oval:test>
                               <oval:object>process58_object</oval:object>
                               <oval:state>process58_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#unix">process58_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:unix">process58_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -1491,7 +1491,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#unix') and ($state_name='process58_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:unix') and ($state_name='process58_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -1620,7 +1620,7 @@
                               <oval:test>routingtable_test</oval:test>
                               <oval:object>routingtable_object</oval:object>
                               <oval:state>routingtable_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#unix">routingtable_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:unix">routingtable_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -1663,7 +1663,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#unix') and ($state_name='routingtable_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:unix') and ($state_name='routingtable_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -1732,7 +1732,7 @@
                               <oval:test>runlevel_test</oval:test>
                               <oval:object>runlevel_object</oval:object>
                               <oval:state>runlevel_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#unix">runlevel_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:unix">runlevel_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -1769,7 +1769,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#unix') and ($state_name='runlevel_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:unix') and ($state_name='runlevel_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -1843,7 +1843,7 @@
                               <oval:test>sccs_test</oval:test>
                               <oval:object>sccs_object</oval:object>
                               <oval:state>sccs_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#unix">sccs_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:unix">sccs_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -1909,7 +1909,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#unix') and ($state_name='sccs_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:unix') and ($state_name='sccs_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -2063,7 +2063,7 @@
                               <oval:test>shadow_test</oval:test>
                               <oval:object>shadow_object</oval:object>
                               <oval:state>shadow_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#unix">shadow_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:unix">shadow_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -2101,7 +2101,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#unix') and ($state_name='shadow_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:unix') and ($state_name='shadow_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -2303,7 +2303,7 @@
                               <oval:test>sshd_test</oval:test>
                               <oval:object>sshd_object</oval:object>
                               <oval:state>sshd_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#unix">sshd_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:unix">sshd_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -2345,7 +2345,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#unix') and ($state_name='sshd_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:unix') and ($state_name='sshd_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -2414,7 +2414,7 @@
                               <oval:test>symlink_test</oval:test>
                               <oval:object>symlink_object</oval:object>
                               <oval:state>symlink_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#unix">symlink_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:unix">symlink_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -2452,7 +2452,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#unix') and ($state_name='symlink_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:unix') and ($state_name='symlink_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -2511,7 +2511,7 @@
                               <oval:test>sysctl_test</oval:test>
                               <oval:object>sysctl_object</oval:object>
                               <oval:state>sysctl_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#unix">sysctl_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:unix">sysctl_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -2548,7 +2548,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#unix') and ($state_name='sysctl_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:unix') and ($state_name='sysctl_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -2607,7 +2607,7 @@
                               <oval:test>uname_test</oval:test>
                               <oval:object>uname_object</oval:object>
                               <oval:state>uname_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#unix">uname_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:unix">uname_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -2696,7 +2696,7 @@
                               <oval:test>xinetd_test</oval:test>
                               <oval:object>xinetd_object</oval:object>
                               <oval:state>xinetd_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#unix">xinetd_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:unix">xinetd_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -2734,7 +2734,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#unix') and ($state_name='xinetd_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:unix') and ($state_name='xinetd_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>

--- a/oval-schemas/unix-system-characteristics-schema.xsd
+++ b/oval-schemas/unix-system-characteristics-schema.xsd
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-            xmlns:oval-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5"
-            xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5"
-            xmlns:unix-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#unix"
+            xmlns:oval-sc="urn:oval:v6:system-characteristics"
+            xmlns:oval="urn:oval:v6:common"
+            xmlns:unix-sc="urn:oval:v6:system-characteristics:unix"
             xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-            targetNamespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#unix"
-            elementFormDefault="qualified" version="5.12">
-     <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5" schemaLocation="oval-system-characteristics-schema.xsd"/>
-     <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-common-5" schemaLocation="oval-common-schema.xsd"/>
+            targetNamespace="urn:oval:v6:system-characteristics:unix"
+            elementFormDefault="qualified" version="6.0">
+     <xsd:import namespace="urn:oval:v6:system-characteristics" schemaLocation="oval-system-characteristics-schema.xsd"/>
+     <xsd:import namespace="urn:oval:v6:common" schemaLocation="oval-common-schema.xsd"/>
      <xsd:annotation>
           <xsd:documentation>The following is a description of the elements, types, and attributes that compose the UNIX specific system characteristic items found in Open Vulnerability and Assessment Language (OVAL). Each item is an extension of the standard item element defined in the Core System Characteristic Schema. Through extension, each item inherits a set of elements and attributes that are shared amongst all OVAL Items. Each item is described in detail and should provide the information necessary to understand what each element and attribute represents. This document is intended for developers and assumes some familiarity with XML. A high level description of the interaction between the different tests and their relationship to the Core System Characteristic Schema is not outlined here.</xsd:documentation>
           <xsd:documentation>The OVAL Schema is maintained by the OVAL Community. For more information, including how to get involved in the project and how to submit change requests, please visit the OVAL website at https://github.com/OVAL-Community/.</xsd:documentation>
           <xsd:appinfo>
                <schema>Unix System Characteristics</schema>
-               <version>5.12</version>
-               <date>11/29/2024 09:00:00 AM</date>
+               <version>6.0</version>
+               <date>1/1/2025 09:00:00 AM</date>
                 <terms_of_use>This software is an open standard developed by multiple parties, including the United States Government (Government). The Government hereby grants you a non-exclusive, royalty-free, worldwide license to use, modify, and/or reproduce the software for any lawful purpose provided that you reproduce this License/Disclaimer language with any use/modification/copy of the software. The Government assumes no responsibility whatsoever for this software's use by other parties, and the software is provided "AS IS" without warranty or guarantee of any kind, express or implied, including, but not limited to, the warranties of merchantability, fitness for a particular purpose, and noninfringement. In no event shall the Government be liable for any claim, damages or other liability, whether in an action of contract, tort or other dealings in the software. The Government has no obligation hereunder to provide maintenance, support, updates, enhancements, or modifications to the software. Users may submit proposals and/or updates regarding the software, which proposals and/or updates the Government, at its sole discretion, can choose to incorporate into the software. Proposals and/or updates submitted to the Government by users must be accompanied by a license to such proposals and/or updates that is no more restrictive than this License/Disclaimer.</terms_of_use>
-               <sch:ns prefix="oval-sc" uri="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5"/>
-               <sch:ns prefix="unix-sc" uri="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#unix"/>
+               <sch:ns prefix="oval-sc" urn="urn:oval:v6:system-characteristics"/>
+               <sch:ns prefix="unix-sc" urn="urn:oval:v6:system-characteristics:unix"/>
               <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
           </xsd:appinfo>
      </xsd:annotation>

--- a/oval-schemas/windows-definitions-schema.xsd
+++ b/oval-schemas/windows-definitions-schema.xsd
@@ -1,22 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-            xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5"
-            xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5"
-            xmlns:win-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows"
+            xmlns:oval="urn:oval:v6:common"
+            xmlns:oval-def="urn:oval:v6:definitions"
+            xmlns:win-def="urn:oval:v6:definitions:windows"
             xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-            targetNamespace="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows"
-            elementFormDefault="qualified" version="5.12">
-      <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-common-5" schemaLocation="oval-common-schema.xsd"/>
-      <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-definitions-5" schemaLocation="oval-definitions-schema.xsd"/>
+            targetNamespace="urn:oval:v6:definitions:windows"
+            elementFormDefault="qualified" version="6.0">
+      <xsd:import namespace="urn:oval:v6:common" schemaLocation="oval-common-schema.xsd"/>
+      <xsd:import namespace="urn:oval:v6:definitions" schemaLocation="oval-definitions-schema.xsd"/>
       <xsd:annotation>
             <xsd:documentation>The following is a description of the elements, types, and attributes that compose the Windows specific tests found in Open Vulnerability and Assessment Language (OVAL). Each test is an extension of the standard test element defined in the Core Definition Schema. Through extension, each test inherits a set of elements and attributes that are shared amongst all OVAL tests. Each test is described in detail and should provide the information necessary to understand what each element and attribute represents. This document is intended for developers and assumes some familiarity with XML. A high level description of the interaction between the different tests and their relationship to the Core Definition Schema is not outlined here.</xsd:documentation>
             <xsd:documentation>The OVAL Schema is maintained by the OVAL Community. For more information, including how to get involved in the project and how to submit change requests, please visit the OVAL website at https://github.com/OVAL-Community/.</xsd:documentation>
             <xsd:appinfo>
                   <schema>Windows Definition</schema>
-                  <version>5.12</version>
-                  <date>11/29/2024 09:00:00 AM</date>
-                  <terms_of_use>This software is an open standard developed by multiple parties, including the United States Government (Government). The Government hereby grants you a non-exclusive, royalty-free, worldwide license to use, modify, and/or reproduce the software for any lawful purpose provided that you reproduce this License/Disclaimer language with any use/modification/copy of the software. The Government assumes no responsibility whatsoever for this software's use by other parties, and the software is provided "AS IS" without warranty or guarantee of any kind, express or implied, including, but not limited to, the warranties of merchantability, fitness for a particular purpose, and noninfringement. In no event shall the Government be liable for any claim, damages or other liability, whether in an action of contract, tort or other dealings in the software. The Government has no obligation hereunder to provide maintenance, support, updates, enhancements, or modifications to the software. Users may submit proposals and/or updates regarding the software, which proposals and/or updates the Government, at its sole discretion, can choose to incorporate into the software. Proposals and/or updates submitted to the Government by users must be accompanied by a license to such proposals and/or updates that is no more restrictive than this License/Disclaimer.</terms_of_use><sch:ns prefix="oval-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5"/>
-                  <sch:ns prefix="win-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows"/>
+                  <version>6.0</version>
+                  <date>1/1/2025 09:00:00 AM</date>
+                  <terms_of_use>This software is an open standard developed by multiple parties, including the United States Government (Government). The Government hereby grants you a non-exclusive, royalty-free, worldwide license to use, modify, and/or reproduce the software for any lawful purpose provided that you reproduce this License/Disclaimer language with any use/modification/copy of the software. The Government assumes no responsibility whatsoever for this software's use by other parties, and the software is provided "AS IS" without warranty or guarantee of any kind, express or implied, including, but not limited to, the warranties of merchantability, fitness for a particular purpose, and noninfringement. In no event shall the Government be liable for any claim, damages or other liability, whether in an action of contract, tort or other dealings in the software. The Government has no obligation hereunder to provide maintenance, support, updates, enhancements, or modifications to the software. Users may submit proposals and/or updates regarding the software, which proposals and/or updates the Government, at its sole discretion, can choose to incorporate into the software. Proposals and/or updates submitted to the Government by users must be accompanied by a license to such proposals and/or updates that is no more restrictive than this License/Disclaimer.</terms_of_use><sch:ns prefix="oval-def" urn="urn:oval:v6:definitions"/>
+                  <sch:ns prefix="win-def" urn="urn:oval:v6:definitions:windows"/>
                   <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
             </xsd:appinfo>
       </xsd:annotation>
@@ -31,7 +31,7 @@
                               <oval:test>accesstoken_test</oval:test>
                               <oval:object>accesstoken_object</oval:object>
                               <oval:state>accesstoken_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#windows">accesstoken_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:windows">accesstoken_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -93,7 +93,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#windows') and ($state_name='accesstoken_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:windows') and ($state_name='accesstoken_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -431,7 +431,7 @@
                               <oval:test>activedirectory_test</oval:test>
                               <oval:object>activedirectory_object</oval:object>
                               <oval:state>activedirectory_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#windows">activedirectory_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:windows">activedirectory_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -551,7 +551,7 @@
                               <oval:test>activedirectory57_test</oval:test>
                               <oval:object>activedirectory57_object</oval:object>
                               <oval:state>activedirectory57_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#windows">activedirectory57_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:windows">activedirectory57_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -602,7 +602,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#windows') and ($state_name='activedirectory57_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:windows') and ($state_name='activedirectory57_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -727,7 +727,7 @@
                               <oval:test>auditeventpolicy_test</oval:test>
                               <oval:object>auditeventpolicy_object</oval:object>
                               <oval:state>auditeventpolicy_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#windows">auditeventpolicy_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:windows">auditeventpolicy_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -837,7 +837,7 @@
                               <oval:test>auditeventpolicysubcategories_test</oval:test>
                               <oval:object>auditeventpolicysubcategories_object</oval:object>
                               <oval:state>auditeventpolicysubcategories_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#windows">auditeventpolicysubcategories_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:windows">auditeventpolicysubcategories_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -1222,7 +1222,7 @@
                               <oval:test>cmdlet_test</oval:test>
                               <oval:object>cmdlet_object</oval:object>
                               <oval:state>cmdlet_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#windows">cmdlet_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:windows">cmdlet_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -1259,7 +1259,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#windows') and ($state_name='cmdlet_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:windows') and ($state_name='cmdlet_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -1461,7 +1461,7 @@
                               <oval:test>dnscache_test</oval:test>
                               <oval:object>dnscache_object</oval:object>
                               <oval:state>dnscache_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#windows">dnscache_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:windows">dnscache_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -1504,7 +1504,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#windows') and ($state_name='dnscache_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:windows') and ($state_name='dnscache_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -1568,7 +1568,7 @@
                               <oval:test>file_test</oval:test>
                               <oval:object>file_object</oval:object>
                               <oval:state>file_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#windows">file_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:windows">file_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -1608,7 +1608,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#windows') and ($state_name='file_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:windows') and ($state_name='file_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -1893,7 +1893,7 @@
                               <oval:test>fileauditedpermissions53_test</oval:test>
                               <oval:object>fileauditedpermissions53_object</oval:object>
                               <oval:state>fileauditedpermissions53_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#windows">fileauditedpermissions_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:windows">fileauditedpermissions_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -1939,7 +1939,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#windows') and ($state_name='fileauditedpermissions53_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:windows') and ($state_name='fileauditedpermissions53_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -2214,7 +2214,7 @@
                               <oval:test>fileauditedpermissions_test</oval:test>
                               <oval:object>fileauditedpermissions_object</oval:object>
                               <oval:state>fileauditedpermissions_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#windows">fileauditedpermissions_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:windows">fileauditedpermissions_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -2515,7 +2515,7 @@
                               <oval:test>fileeffectiverights53_test</oval:test>
                               <oval:object>fileeffectiverights53_object</oval:object>
                               <oval:state>fileeffectiverights53_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#windows">fileeffectiverights_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:windows">fileeffectiverights_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -2555,7 +2555,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#windows') and ($state_name='fileeffectiverights53_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:windows') and ($state_name='fileeffectiverights53_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -2830,7 +2830,7 @@
                               <oval:test>fileeffectiverights_test</oval:test>
                               <oval:object>fileeffectiverights_object</oval:object>
                               <oval:state>fileeffectiverights_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#windows">fileeffectiverights_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:windows">fileeffectiverights_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -3131,7 +3131,7 @@
                               <oval:test>group_test</oval:test>
                               <oval:object>group_object</oval:object>
                               <oval:state>group_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#windows">group_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:windows">group_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -3198,7 +3198,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#windows') and ($state_name='group_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:windows') and ($state_name='group_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -3276,7 +3276,7 @@
                               <oval:test>group_sid_test</oval:test>
                               <oval:object>group_sid_object</oval:object>
                               <oval:state>group_sid_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#windows">group_sid_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:windows">group_sid_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -3313,7 +3313,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#windows') and ($state_name='group_sid_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:windows') and ($state_name='group_sid_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -3394,7 +3394,7 @@
                               <oval:test>interface_test</oval:test>
                               <oval:object>interface_object</oval:object>
                               <oval:state>interface_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#windows">interface_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:windows">interface_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -3438,7 +3438,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#windows') and ($state_name='interface_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:windows') and ($state_name='interface_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -3527,7 +3527,7 @@
                               <oval:test>junction_test</oval:test>
                               <oval:object>junction_object</oval:object>
                               <oval:state>junction_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#windows">junction_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:windows">junction_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -3571,7 +3571,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#windows') and ($state_name='junction_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:windows') and ($state_name='junction_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -3713,7 +3713,7 @@
                               <oval:test>lockoutpolicy_test</oval:test>
                               <oval:object>lockoutpolicy_object</oval:object>
                               <oval:state>lockoutpolicy_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#windows">lockoutpolicy_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:windows">lockoutpolicy_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -3806,7 +3806,7 @@
                               <oval:test>metabase_test</oval:test>
                               <oval:object>metabase_object</oval:object>
                               <oval:state>metabase_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#windows">metabase_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:windows">metabase_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -3850,7 +3850,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#windows') and ($state_name='metabase_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:windows') and ($state_name='metabase_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -3936,7 +3936,7 @@
                               <oval:test>ntuser_test</oval:test>
                               <oval:object>ntuser_object</oval:object>
                               <oval:state>ntuser_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#windows">ntuser_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:windows">ntuser_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -3975,7 +3975,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#windows') and ($state_name='ntuser_state'))">State referenced in filter for
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:windows') and ($state_name='ntuser_state'))">State referenced in filter for
                                           <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
@@ -4192,7 +4192,7 @@
                               <oval:test>passwordpolicy_test</oval:test>
                               <oval:object>passwordpolicy_object</oval:object>
                               <oval:state>passwordpolicy_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#windows">passwordpolicy_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:windows">passwordpolicy_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -4293,7 +4293,7 @@
                               <oval:test>peheader_test</oval:test>
                               <oval:object>peheader_object</oval:object>
                               <oval:state>peheader_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#windows">peheader_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:windows">peheader_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -4697,7 +4697,7 @@
                               <oval:test>port_test</oval:test>
                               <oval:object>port_object</oval:object>
                               <oval:state>port_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#windows">port_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:windows">port_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -4741,7 +4741,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#windows') and ($state_name='port_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:windows') and ($state_name='port_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -4830,7 +4830,7 @@
                               <oval:test>printereffectiverights_test</oval:test>
                               <oval:object>printereffectiverights_object</oval:object>
                               <oval:state>printereffectiverights_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#windows">printereffectiverights_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:windows">printereffectiverights_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -4873,7 +4873,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#windows') and ($state_name='printereffectiverights_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:windows') and ($state_name='printereffectiverights_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -5047,7 +5047,7 @@
                               <oval:test>process_test</oval:test>
                               <oval:object>process_object</oval:object>
                               <oval:state>process_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#windows">process_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:windows">process_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -5195,7 +5195,7 @@
                               <oval:test>process58_test</oval:test>
                               <oval:object>process58_object</oval:object>
                               <oval:state>process58_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#windows">process_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:windows">process_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -5239,7 +5239,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#windows') and ($state_name='process58_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:windows') and ($state_name='process58_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -5357,7 +5357,7 @@
                               <oval:test>registry_test</oval:test>
                               <oval:object>registry_object</oval:object>
                               <oval:state>registry_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#windows">registry_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:windows">registry_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -5394,7 +5394,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#windows') and ($state_name='registry_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:windows') and ($state_name='registry_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -5546,7 +5546,7 @@
                               <oval:test>regkeyauditedpermissions53_test</oval:test>
                               <oval:object>regkeyauditedpermissions53_object</oval:object>
                               <oval:state>regkeyauditedpermissions53_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#windows">regkeyauditedpermissions_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:windows">regkeyauditedpermissions_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -5590,7 +5590,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#windows') and ($state_name='regkeyauditedpermissions53_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:windows') and ($state_name='regkeyauditedpermissions53_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -5833,7 +5833,7 @@
                               <oval:test>regkeyauditedpermissions_test</oval:test>
                               <oval:object>regkeyauditedpermissions_object</oval:object>
                               <oval:state>regkeyauditedpermissions_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#windows">regkeyauditedpermissions_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:windows">regkeyauditedpermissions_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -6127,7 +6127,7 @@
                               <oval:test>regkeyeffectiverights53_test</oval:test>
                               <oval:object>regkeyeffectiverights53_object</oval:object>
                               <oval:state>regkeyeffectiverights53_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#windows">regkeyeffectiverights_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:windows">regkeyeffectiverights_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -6165,7 +6165,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#windows') and ($state_name='regkeyeffectiverights53_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:windows') and ($state_name='regkeyeffectiverights53_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -6408,7 +6408,7 @@
                               <oval:test>regkeyeffectiverights_test</oval:test>
                               <oval:object>regkeyeffectiverights_object</oval:object>
                               <oval:state>regkeyeffectiverights_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#windows">regkeyeffectiverights_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:windows">regkeyeffectiverights_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -6700,7 +6700,7 @@
                               <oval:test>service_test</oval:test>
                               <oval:object>service_object</oval:object>
                               <oval:state>service_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#windows">service_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:windows">service_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -6737,7 +6737,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#windows') and ($state_name='service_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:windows') and ($state_name='service_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -6846,7 +6846,7 @@
                               <oval:test>serviceeffectiverights_test</oval:test>
                               <oval:object>serviceeffectiverights_object</oval:object>
                               <oval:state>serviceeffectiverights_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#windows">serviceeffectiverights_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:windows">serviceeffectiverights_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -6890,7 +6890,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#windows') and ($state_name='serviceeffectiverights_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:windows') and ($state_name='serviceeffectiverights_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -7075,7 +7075,7 @@
                               <oval:test>sharedresource_test</oval:test>
                               <oval:object>sharedresource_object</oval:object>
                               <oval:state>sharedresource_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#windows">sharedresource_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:windows">sharedresource_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -7119,7 +7119,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#windows') and ($state_name='sharedresource_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:windows') and ($state_name='sharedresource_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -7233,7 +7233,7 @@
                               <oval:test>sharedresourceauditedpermissions_test</oval:test>
                               <oval:object>sharedresourceauditedpermissions_object</oval:object>
                               <oval:state>sharedresourceauditedpermissions_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#windows">sharedresourceauditedpermissions_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:windows">sharedresourceauditedpermissions_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -7277,7 +7277,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#windows') and ($state_name='sharedresourceauditedpermissions_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:windows') and ($state_name='sharedresourceauditedpermissions_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -7414,7 +7414,7 @@
                               <oval:test>sharedresourceeffectiverights_test</oval:test>
                               <oval:object>sharedresourceeffectiverights_object</oval:object>
                               <oval:state>sharedresourceeffectiverights_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#windows">sharedresourceeffectiverights_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:windows">sharedresourceeffectiverights_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -7458,7 +7458,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#windows') and ($state_name='sharedresourceeffectiverights_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:windows') and ($state_name='sharedresourceeffectiverights_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -7595,7 +7595,7 @@
                               <oval:test>sid_test</oval:test>
                               <oval:object>sid_object</oval:object>
                               <oval:state>sid_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#windows">sid_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:windows">sid_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -7632,7 +7632,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#windows') and ($state_name='sid_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:windows') and ($state_name='sid_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -7713,7 +7713,7 @@
                               <oval:test>sid_sid_test</oval:test>
                               <oval:object>sid_sid_object</oval:object>
                               <oval:state>sid_sid_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#windows">sid_sid_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:windows">sid_sid_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -7750,7 +7750,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#windows') and ($state_name='sid_sid_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:windows') and ($state_name='sid_sid_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -7901,7 +7901,7 @@
                               <oval:test>uac_test</oval:test>
                               <oval:object>uac_object</oval:object>
                               <oval:state>uac_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#windows">uac_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:windows">uac_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -8011,7 +8011,7 @@
                               <oval:test>user_test</oval:test>
                               <oval:object>user_object</oval:object>
                               <oval:state>user_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#windows">user_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:windows">user_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -8072,7 +8072,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#windows') and ($state_name='user_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:windows') and ($state_name='user_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -8224,7 +8224,7 @@
                           <oval:test>user_sid55_test</oval:test>
                           <oval:object>user_sid55_object</oval:object>
                           <oval:state>user_sid55_state</oval:state>
-                          <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#windows">user_sid_item</oval:item>
+                          <oval:item target_namespace="urn:oval:v6:system-characteristics:windows">user_sid_item</oval:item>
                     </oval:element_mapping>
               </xsd:appinfo>
               <xsd:appinfo>
@@ -8261,7 +8261,7 @@
                           <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                           <sch:let name="state_name" value="local-name($reffed_state)"/>
                           <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                          <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#windows') and ($state_name='user_sid55_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                          <sch:assert test="(($state_namespace='urn:oval:v6:definitions:windows') and ($state_name='user_sid55_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                     </sch:rule>
               </sch:pattern>
             </xsd:appinfo>
@@ -8341,7 +8341,7 @@
                               <oval:test>user_sid_test</oval:test>
                               <oval:object>user_sid_object</oval:object>
                               <oval:state>user_sid_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#windows">user_sid_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:windows">user_sid_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -8462,7 +8462,7 @@
                               <oval:test>userright_test</oval:test>
                               <oval:object>userright_object</oval:object>
                               <oval:state>userright_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#windows">userright_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:windows">userright_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -8499,7 +8499,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#windows') and ($state_name='userright_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:windows') and ($state_name='userright_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -8563,7 +8563,7 @@
                               <oval:test>appcmd_test</oval:test>
                               <oval:object>appcmd_object</oval:object>
                               <oval:state>appcmd_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#windows">appcmd_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:windows">appcmd_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -8600,7 +8600,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#windows') and ($state_name='appcmd_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:windows') and ($state_name='appcmd_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -8679,7 +8679,7 @@
                               <oval:test>appcmdlistconfig_test</oval:test>
                               <oval:object>appcmdlistconfig_object</oval:object>
                               <oval:state>appcmdlistconfig_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#windows">appcmdlistconfig_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:windows">appcmdlistconfig_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -8716,7 +8716,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#windows') and ($state_name='appcmdlistconfig_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:windows') and ($state_name='appcmdlistconfig_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -8805,7 +8805,7 @@
                               <oval:test>volume_test</oval:test>
                               <oval:object>volume_object</oval:object>
                               <oval:state>volume_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#windows">volume_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:windows">volume_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
 					<xsd:appinfo>
@@ -8849,7 +8849,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#windows') and ($state_name='volume_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:windows') and ($state_name='volume_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -9028,7 +9028,7 @@
                               <oval:test>wmi_test</oval:test>
                               <oval:object>wmi_object</oval:object>
                               <oval:state>wmi_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#windows">wmi_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:windows">wmi_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -9170,7 +9170,7 @@
                               <oval:test>wmi57_test</oval:test>
                               <oval:object>wmi57_object</oval:object>
                               <oval:state>wmi57_state</oval:state>
-                              <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#windows">wmi57_item</oval:item>
+                              <oval:item target_namespace="urn:oval:v6:system-characteristics:windows">wmi57_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
@@ -9207,7 +9207,7 @@
                                     <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                     <sch:let name="state_name" value="local-name($reffed_state)"/>
                                     <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                    <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#windows') and ($state_name='wmi57_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                    <sch:assert test="(($state_namespace='urn:oval:v6:definitions:windows') and ($state_name='wmi57_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                               </sch:rule>
                         </sch:pattern>
                   </xsd:appinfo>
@@ -9302,7 +9302,7 @@
                           <oval:test>wuaupdatesearcher_test</oval:test>
                           <oval:object>wuaupdatesearcher_object</oval:object>
                           <oval:state>wuaupdatesearcher_state</oval:state>
-                          <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#windows">wuaupdatesearcher_item</oval:item>
+                          <oval:item target_namespace="urn:oval:v6:system-characteristics:windows">wuaupdatesearcher_item</oval:item>
                     </oval:element_mapping>
               </xsd:appinfo>
 					<xsd:appinfo>
@@ -9349,7 +9349,7 @@
                                 <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
                                 <sch:let name="state_name" value="local-name($reffed_state)"/>
                                 <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
-                                <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/oval-definitions-5#windows') and ($state_name='wuaupdatesearcher_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                                <sch:assert test="(($state_namespace='urn:oval:v6:definitions:windows') and ($state_name='wuaupdatesearcher_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
                           </sch:rule>
                     </sch:pattern>
               </xsd:appinfo>

--- a/oval-schemas/windows-system-characteristics-schema.xsd
+++ b/oval-schemas/windows-system-characteristics-schema.xsd
@@ -1,22 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-            xmlns:oval-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5"
-            xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5"
-            xmlns:win-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#windows"
+            xmlns:oval-sc="urn:oval:v6:system-characteristics"
+            xmlns:oval="urn:oval:v6:common"
+            xmlns:win-sc="urn:oval:v6:system-characteristics:windows"
             xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-            targetNamespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#windows"
-            elementFormDefault="qualified" version="5.12">
-     <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-common-5" schemaLocation="oval-common-schema.xsd"/>
-     <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5" schemaLocation="oval-system-characteristics-schema.xsd"/>
+            targetNamespace="urn:oval:v6:system-characteristics:windows"
+            elementFormDefault="qualified" version="6.0">
+     <xsd:import namespace="urn:oval:v6:common" schemaLocation="oval-common-schema.xsd"/>
+     <xsd:import namespace="urn:oval:v6:system-characteristics" schemaLocation="oval-system-characteristics-schema.xsd"/>
      <xsd:annotation>
           <xsd:documentation>The following is a description of the elements, types, and attributes that compose the Windows specific system characteristic items found in Open Vulnerability and Assessment Language (OVAL). Each item is an extension of the standard item element defined in the Core System Characteristic Schema. Through extension, each item inherits a set of elements and attributes that are shared amongst all OVAL Items. Each item is described in detail and should provide the information necessary to understand what each element and attribute represents. This document is intended for developers and assumes some familiarity with XML. A high level description of the interaction between the different tests and their relationship to the Core System Characteristic Schema is not outlined here.</xsd:documentation>
           <xsd:documentation>The OVAL Schema is maintained by the OVAL Community. For more information, including how to get involved in the project and how to submit change requests, please visit the OVAL website at https://github.com/OVAL-Community/.</xsd:documentation>
           <xsd:appinfo>
                <schema>Windows System Characteristics</schema>
-               <version>5.12</version>
-               <date>11/29/2024 09:00:00 AM</date>
-               <terms_of_use>This software is an open standard developed by multiple parties, including the United States Government (Government). The Government hereby grants you a non-exclusive, royalty-free, worldwide license to use, modify, and/or reproduce the software for any lawful purpose provided that you reproduce this License/Disclaimer language with any use/modification/copy of the software. The Government assumes no responsibility whatsoever for this software's use by other parties, and the software is provided "AS IS" without warranty or guarantee of any kind, express or implied, including, but not limited to, the warranties of merchantability, fitness for a particular purpose, and noninfringement. In no event shall the Government be liable for any claim, damages or other liability, whether in an action of contract, tort or other dealings in the software. The Government has no obligation hereunder to provide maintenance, support, updates, enhancements, or modifications to the software. Users may submit proposals and/or updates regarding the software, which proposals and/or updates the Government, at its sole discretion, can choose to incorporate into the software. Proposals and/or updates submitted to the Government by users must be accompanied by a license to such proposals and/or updates that is no more restrictive than this License/Disclaimer.</terms_of_use><sch:ns prefix="oval-sc" uri="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5"/>
-               <sch:ns prefix="win-sc" uri="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#windows"/>
+               <version>6.0</version>
+               <date>1/1/2025 09:00:00 AM</date>
+               <terms_of_use>This software is an open standard developed by multiple parties, including the United States Government (Government). The Government hereby grants you a non-exclusive, royalty-free, worldwide license to use, modify, and/or reproduce the software for any lawful purpose provided that you reproduce this License/Disclaimer language with any use/modification/copy of the software. The Government assumes no responsibility whatsoever for this software's use by other parties, and the software is provided "AS IS" without warranty or guarantee of any kind, express or implied, including, but not limited to, the warranties of merchantability, fitness for a particular purpose, and noninfringement. In no event shall the Government be liable for any claim, damages or other liability, whether in an action of contract, tort or other dealings in the software. The Government has no obligation hereunder to provide maintenance, support, updates, enhancements, or modifications to the software. Users may submit proposals and/or updates regarding the software, which proposals and/or updates the Government, at its sole discretion, can choose to incorporate into the software. Proposals and/or updates submitted to the Government by users must be accompanied by a license to such proposals and/or updates that is no more restrictive than this License/Disclaimer.</terms_of_use><sch:ns prefix="oval-sc" urn="urn:oval:v6:system-characteristics"/>
+               <sch:ns prefix="win-sc" urn="urn:oval:v6:system-characteristics:windows"/>
               <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
           </xsd:appinfo>
      </xsd:annotation>


### PR DESCRIPTION
Updated all MITRE centric URL namespaces with URN based OVAL 6 namespaces.  Note that I accidentally created this branch from 'master' instead of oval6-develop, so there are 2 .rst files with updates (that can be ignored for the scope of this PR)