### PR TITLE
Removed platforms from offline HTML documentation that have been removed in OVAL 6

### DIFF
--- a/rsrc/index.html
+++ b/rsrc/index.html
@@ -47,10 +47,6 @@
               <td><a href="oval-directives-schema.html">html</a></td>
             </tr>
             <tr>
-              <td>Evaluation-IDs</td>
-              <td><a href="evaluation-ids.html">html</a></td>
-            </tr>
-            <tr>
               <td>External Variables</td>
               <td><a href="oval-variables-schema.html">html</a></td>
             </tr>
@@ -68,7 +64,7 @@
         <th>System-Characteristics</th>
       </tr>
       <tr>
-        <td>Platform-Independent</td>
+        <td>Independent</td>
         <td><a href="independent-definitions-schema.html">html</a></td>
         <td><a href="independent-system-characteristics-schema.html">html</a></td>
       </tr>
@@ -81,30 +77,12 @@
         <td><a href="aws-system-characteristics-schema.html">html</a></td>
       </tr>
       <tr>
-        <td bgcolor="#F0F0F0" colspan="3"><h3>Mobile Device Schemas</h3></td>
-      </tr>
-      <tr>
-        <td>Apple iOS</td>
-        <td><a href="apple-ios-definitions-schema.html">html</a></td>
-        <td><a href="apple-ios-system-characteristics-schema.html">html</a></td>
-      </tr>
-      <tr>
-        <td>Google Andriod</td>
-        <td><a href="android-definitions-schema.html">html</a></td>
-        <td><a href="android-system-characteristics-schema.html">html</a></td>
-      </tr>
-      <tr>
         <td bgcolor="#F0F0F0" colspan="3"><h3>Network Device Schemas</h3></td>
       </tr>
       <tr>
         <td>Cisco ASA</td>
         <td><a href="asa-definitions-schema.html">html</a></td>
         <td><a href="asa-system-characteristics-schema.html">html</a></td>
-      </tr>
-      <tr>
-        <td>Cisco CATOS</td>
-        <td><a href="catos-definitions-schema.html">html</a></td>
-        <td><a href="catos-system-characteristics-schema.html">html</a></td>
       </tr>
       <tr>
         <td>Cisco IOS</td>
@@ -117,19 +95,9 @@
         <td><a href="iosxe-system-characteristics-schema.html">html</a></td>
       </tr>
       <tr>
-        <td>Cisco PIX</td>
-        <td><a href="pixos-definitions-schema.html">html</a></td>
-        <td><a href="pixos-system-characteristics-schema.html">html</a></td>
-      </tr>
-      <tr>
         <td>Juniper JunOS</td>
         <td><a href="junos-definitions-schema.html">html</a></td>
         <td><a href="junos-system-characteristics-schema.html">html</a></td>
-      </tr>
-      <tr>
-        <td>NETCONF</td>
-        <td><a href="netconf-definitions-schema.html">html</a></td>
-        <td><a href="netconf-system-characteristics-schema.html">html</a></td>
       </tr>
       <tr>
         <td>Palo Alto PAN-OS</td>
@@ -145,11 +113,6 @@
         <td><a href="windows-system-characteristics-schema.html">html</a></td>
       </tr>
       <tr>
-        <td>Sharepoint</td>
-        <td><a href="sharepoint-definitions-schema.html">html</a></td>
-        <td><a href="sharepoint-system-characteristics-schema.html">html</a></td>
-      </tr>
-      <tr>
         <td bgcolor="#F0F0F0" colspan="3"><h3>Unix Operating Systems</h3></td>
       </tr>
       <tr>
@@ -161,16 +124,6 @@
         <td>Apple MacOS</td>
         <td><a href="macos-definitions-schema.html">html</a></td>
         <td><a href="macos-system-characteristics-schema.html">html</a></td>
-      </tr>
-      <tr>
-        <td>FreeBSD</td>
-        <td><a href="freebsd-definitions-schema.html">html</a></td>
-        <td><a href="freebsd-system-characteristics-schema.html">html</a></td>
-      </tr>
-      <tr>
-        <td>HP-UX</td>
-        <td><a href="hpux-definitions-schema.html">html</a></td>
-        <td><a href="hpux-system-characteristics-schema.html">html</a></td>
       </tr>
       <tr>
         <td>IBM AIX</td>
@@ -191,14 +144,6 @@
         <td>VMWare ESX</td>
         <td><a href="esx-definitions-schema.html">html</a></td>
         <td><a href="esx-system-characteristics-schema.html">html</a></td>
-      </tr>
-      <tr>
-        <td bgcolor="#F0F0F0" colspan="3"><h3>Application-Specific Schemas</h3></td>
-      </tr>
-      <tr>
-        <td>Apache</td>
-        <td><a href="apache-definitions-schema.html">html</a></td>
-        <td><a href="apache-system-characteristics-schema.html">html</a></td>
       </tr>
     </table>
   </body>


### PR DESCRIPTION
Need to update before the OVAL 6.0 release, as this file is not programmatically generated.