### PR TITLE
Resolved #242 by adding full_name, comment and password_age_days to user_sid55 state and item

### DIFF
--- a/oval-schemas/windows-definitions-schema.xsd
+++ b/oval-schemas/windows-definitions-schema.xsd
@@ -2692,37 +2692,52 @@
             <xsd:complexContent>
                 <xsd:extension base="oval-def:StateType">
                     <xsd:sequence>
-                        <xsd:element name="user_sid" type="oval-def:EntityStateStringType" minOccurs="0">
-                            <xsd:annotation>
-                                <xsd:documentation>The user_sid entity holds a string that represents the SID of a particular user.</xsd:documentation>
-                            </xsd:annotation>
-                        </xsd:element>
-                        <xsd:element name="enabled" type="oval-def:EntityStateBoolType" minOccurs="0">
-                            <xsd:annotation>
-                                <xsd:documentation>This element holds a boolean value that specifies whether the particular user account is enabled or not.</xsd:documentation>
-                            </xsd:annotation>
-                        </xsd:element>
-                        <xsd:element name="group_sid" type="oval-def:EntityStateStringType" minOccurs="0">
-                            <xsd:annotation>
-                                <xsd:documentation>A string the represents the SID of a particular group.  The group_sid element can be included multiple times in a system characteristic item in order to record that a user can be a member of a number of different groups. Note that the entity_check attribute associated with EntityStateStringType guides the evaluation of entities like group that refer to items that can occur an unbounded number of times.</xsd:documentation>
-                            </xsd:annotation>
-                        </xsd:element>
-                        <xsd:element name="last_logon" type="oval-def:EntityStateIntType" minOccurs="0">
-                            <xsd:annotation>
-                                <xsd:documentation>The date and time when the last logon occurred. This value is stored as the number of seconds that have elapsed since 00:00:00, January 1, 1970, GMT.</xsd:documentation>
-                            </xsd:annotation>
-                        </xsd:element>
-					  <xsd:element name="user" type="oval-def:EntityStateStringType" minOccurs="0">
+						<xsd:element name="user_sid" type="oval-def:EntityStateStringType" minOccurs="0">
+							<xsd:annotation>
+								<xsd:documentation>The user_sid entity holds a string that represents the SID of a particular user.</xsd:documentation>
+							</xsd:annotation>
+						</xsd:element>
+						<xsd:element name="enabled" type="oval-def:EntityStateBoolType" minOccurs="0">
+							<xsd:annotation>
+								<xsd:documentation>This element holds a boolean value that specifies whether the particular user account is enabled or not.</xsd:documentation>
+							</xsd:annotation>
+						</xsd:element>
+						<xsd:element name="group_sid" type="oval-def:EntityStateStringType" minOccurs="0">
+							<xsd:annotation>
+								<xsd:documentation>A string the represents the SID of a particular group.  The group_sid element can be included multiple times in a system characteristic item in order to record that a user can be a member of a number of different groups. Note that the entity_check attribute associated with EntityStateStringType guides the evaluation of entities like group that refer to items that can occur an unbounded number of times.</xsd:documentation>
+							</xsd:annotation>
+						</xsd:element>
+						<xsd:element name="last_logon" type="oval-def:EntityStateIntType" minOccurs="0">
+							<xsd:annotation>
+								<xsd:documentation>The date and time when the last logon occurred. This value is stored as the number of seconds that have elapsed since 00:00:00, January 1, 1970, GMT.</xsd:documentation>
+							</xsd:annotation>
+						</xsd:element>
+						<xsd:element name="user" type="oval-def:EntityStateStringType" minOccurs="0">
 						   <xsd:annotation>
 								<xsd:documentation>A string the represents the name of a particular user. In Windows, user names are case-insensitive. As a result, it is recommended that the case-insensitive operations are used for this entity. In a domain environment, users should be identified in the form: "domain\user name". For local users use: "computer_name\user_name". For built-in accounts on the system, use the user name without a domain.</xsd:documentation>
 						   </xsd:annotation>
-					  </xsd:element>
-					  <xsd:element name="group" type="oval-def:EntityStateStringType" minOccurs="0">
+						</xsd:element>
+						<xsd:element name="group" type="oval-def:EntityStateStringType" minOccurs="0">
 						   <xsd:annotation>
 								<xsd:documentation>A string that represents the name of a particular group. In Windows, group names are case-insensitive. As a result, it is recommended that the case-insensitive operations are used for this entity. In a domain environment, groups should be identified in the form: "domain\group name". For local groups use: "computer name\group name". For built-in accounts on the system, use the group name without a domain.</xsd:documentation>
 								<xsd:documentation>If the specified user belongs to more than one group, then multiple group elements should exist. If the specified user is not a member of a single group, then a single group element should exist with a status of 'does not exist'. If there is an error determining the groups that the user belongs to, then a single group element should be included with a status of 'error'.</xsd:documentation>
 						   </xsd:annotation>
-					  </xsd:element>
+						</xsd:element>
+						<xsd:element name="full_name" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+						  <xsd:annotation>
+								<xsd:documentation>A Unicode string that contains the full name of the user. This string can be a NULL string, or it can have any number of characters before the terminating null character.</xsd:documentation>
+						  </xsd:annotation>
+						</xsd:element>
+						<xsd:element name="comment" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+						  <xsd:annotation>
+								<xsd:documentation>A Unicode string that contains a comment to associate with the user account. The string can be a NULL string, or it can have any number of characters before the terminating null character.</xsd:documentation>
+						  </xsd:annotation>
+						</xsd:element>
+						<xsd:element name="password_age_days" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+						  <xsd:annotation>
+								<xsd:documentation>The number of days that have elapsed since the password was last changed. This data should be rounded up to the nearest integer.</xsd:documentation>
+						  </xsd:annotation>
+						</xsd:element>
                     </xsd:sequence>
                 </xsd:extension>
             </xsd:complexContent>

--- a/oval-schemas/windows-system-characteristics-schema.xsd
+++ b/oval-schemas/windows-system-characteristics-schema.xsd
@@ -1441,16 +1441,31 @@
                                             <xsd:documentation>The date and time when the last logon occurred. This value is stored as the number of seconds that have elapsed since 00:00:00, January 1, 1970, GMT.</xsd:documentation>
                                        </xsd:annotation>
                                   </xsd:element>
-                              <xsd:element name="user" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
-                                   <xsd:annotation>
-                                        <xsd:documentation>A string the represents the name of a particular user. In Windows, user names are case-insensitive. As a result, it is recommended that the case-insensitive operations are used for this entity. In a domain environment, users should be identified in the form: "domain\user name". For local users use: "computer_name\user_name". For built-in accounts on the system, use the user name without a domain.</xsd:documentation>
-                                   </xsd:annotation>
-                              </xsd:element>
-                              <xsd:element name="group" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="unbounded">
-                                   <xsd:annotation>
-                                        <xsd:documentation>A string that represents the name of a particular group. In Windows, group names are case-insensitive. As a result, it is recommended that the case-insensitive operations are used for this entity. In a domain environment, groups should be identified in the form: "domain\group name". For local groups use: "computer name\group name". For built-in accounts on the system, use the group name without a domain.</xsd:documentation>
-                                        <xsd:documentation>If the specified user belongs to more than one group, then multiple group elements should exist. If the specified user is not a member of a single group, then a single group element should exist with a status of 'does not exist'. If there is an error determining the groups that the user belongs to, then a single group element should be included with a status of 'error'.</xsd:documentation>
-                                   </xsd:annotation>
+								  <xsd:element name="user" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+									   <xsd:annotation>
+											<xsd:documentation>A string the represents the name of a particular user. In Windows, user names are case-insensitive. As a result, it is recommended that the case-insensitive operations are used for this entity. In a domain environment, users should be identified in the form: "domain\user name". For local users use: "computer_name\user_name". For built-in accounts on the system, use the user name without a domain.</xsd:documentation>
+									   </xsd:annotation>
+								  </xsd:element>
+								  <xsd:element name="group" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="unbounded">
+									   <xsd:annotation>
+											<xsd:documentation>A string that represents the name of a particular group. In Windows, group names are case-insensitive. As a result, it is recommended that the case-insensitive operations are used for this entity. In a domain environment, groups should be identified in the form: "domain\group name". For local groups use: "computer name\group name". For built-in accounts on the system, use the group name without a domain.</xsd:documentation>
+											<xsd:documentation>If the specified user belongs to more than one group, then multiple group elements should exist. If the specified user is not a member of a single group, then a single group element should exist with a status of 'does not exist'. If there is an error determining the groups that the user belongs to, then a single group element should be included with a status of 'error'.</xsd:documentation>
+									   </xsd:annotation>
+								  </xsd:element>
+								  <xsd:element name="full_name" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+									   <xsd:annotation>
+											<xsd:documentation>A Unicode string that contains the full name of the user. This string can be a NULL string, or it can have any number of characters before the terminating null character.</xsd:documentation>
+									   </xsd:annotation>
+								  </xsd:element>
+								  <xsd:element name="comment" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+									   <xsd:annotation>
+											<xsd:documentation>A Unicode string that contains a comment to associate with the user account. The string can be a NULL string, or it can have any number of characters before the terminating null character.</xsd:documentation>
+									   </xsd:annotation>
+								  </xsd:element>
+								  <xsd:element name="password_age_days" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
+									   <xsd:annotation>
+											<xsd:documentation>The number of full days that have elapsed since the password was last changed, meaning data calulated should be truncated. Ex: 89.5 days = 89, 90.01 = 90</xsd:documentation>
+									   </xsd:annotation>
                               </xsd:element>
                              </xsd:sequence>
                        </xsd:extension>


### PR DESCRIPTION
In order to maintain functionality from OVAL 5.11.2, these elements are needed, as we dropped the windows user test