### PR TITLE
OVAL 5.12.1 update independent shellcommand state  command to have minoccurs 0

### DIFF
--- a/guidelines/index.rst
+++ b/guidelines/index.rst
@@ -5,7 +5,7 @@
 
 .. _welcome-to-the-guidelines:
 
-The OVAL Community Version 5.12 Documenation
+The OVAL Community Version 5.12 Documentation
 =========================================
 
 Welcome to the guidelines for OVAL, the Open Vulnerability and Assessment Language. These guidelines are designed to explain everything you need to know to start contributing to OVAL (or link you to places to ask questions, should the explanations not suffice), as well as provide a variety of standards and resources to the community.

--- a/oval-schemas/independent-definitions-schema.xsd
+++ b/oval-schemas/independent-definitions-schema.xsd
@@ -1095,7 +1095,7 @@ A subexpression (using parentheses) can call out a piece of the matched stdout_l
                                           </xsd:annotation>
                                     </xsd:element>
                                     
-                                    <xsd:element name="command" type="oval-def:EntityStateAnySimpleType" minOccurs="1" maxOccurs="1">
+                                    <xsd:element name="command" type="oval-def:EntityStateAnySimpleType" minOccurs="0" maxOccurs="1">
                                           <xsd:annotation>
                                                 <xsd:documentation>The 'command' element specifies the command string to be run on the target system and must match the same element in the associated shellcommand_object, verbatim.</xsd:documentation>
                                           </xsd:annotation>


### PR DESCRIPTION
Trivial change, minOccurs = 0 for 'command' on state