### PR TITLE
Resolved #249 updated state minoccurs from 1 to zero for 'command'

### DIFF
--- a/oval-schemas/independent-definitions-schema.xsd
+++ b/oval-schemas/independent-definitions-schema.xsd
@@ -480,7 +480,7 @@ A subexpression (using parentheses) can call out a piece of the matched stdout_l
                                           </xsd:annotation>
                                     </xsd:element>
                                     
-                                    <xsd:element name="command" type="oval-def:EntityStateAnySimpleType" minOccurs="1" maxOccurs="1">
+                                    <xsd:element name="command" type="oval-def:EntityStateAnySimpleType" minOccurs="0" maxOccurs="1">
                                           <xsd:annotation>
                                                 <xsd:documentation>The 'command' element specifies the command string to be run on the target system and must match the same element in the associated shellcommand_object, verbatim.</xsd:documentation>
                                           </xsd:annotation>


### PR DESCRIPTION
Trivial typo fix, changing minOccurs from 1 to 0 this time on the 6.0.1 develop branch