### PR TITLE
Resolved #242 in OVAL 5.12.1 by adding full_name, comment and password_age_days to user_sid55 state and item""

### DIFF
--- a/oval-schemas/windows-definitions-schema.xsd
+++ b/oval-schemas/windows-definitions-schema.xsd
@@ -8299,37 +8299,52 @@
             <xsd:complexContent>
                 <xsd:extension base="oval-def:StateType">
                     <xsd:sequence>
-                        <xsd:element name="user_sid" type="oval-def:EntityStateStringType" minOccurs="0">
-                            <xsd:annotation>
-                                <xsd:documentation>The user_sid entity holds a string that represents the SID of a particular user.</xsd:documentation>
-                            </xsd:annotation>
-                        </xsd:element>
-                        <xsd:element name="enabled" type="oval-def:EntityStateBoolType" minOccurs="0">
-                            <xsd:annotation>
-                                <xsd:documentation>This element holds a boolean value that specifies whether the particular user account is enabled or not.</xsd:documentation>
-                            </xsd:annotation>
-                        </xsd:element>
-                        <xsd:element name="group_sid" type="oval-def:EntityStateStringType" minOccurs="0">
-                            <xsd:annotation>
-                                <xsd:documentation>A string the represents the SID of a particular group.  The group_sid element can be included multiple times in a system characteristic item in order to record that a user can be a member of a number of different groups. Note that the entity_check attribute associated with EntityStateStringType guides the evaluation of entities like group that refer to items that can occur an unbounded number of times.</xsd:documentation>
-                            </xsd:annotation>
-                        </xsd:element>
-                        <xsd:element name="last_logon" type="oval-def:EntityStateIntType" minOccurs="0">
-                            <xsd:annotation>
-                                <xsd:documentation>The date and time when the last logon occurred. This value is stored as the number of seconds that have elapsed since 00:00:00, January 1, 1970, GMT.</xsd:documentation>
-                            </xsd:annotation>
-                        </xsd:element>
-					  <xsd:element name="user" type="oval-def:EntityStateStringType" minOccurs="0">
+						<xsd:element name="user_sid" type="oval-def:EntityStateStringType" minOccurs="0">
+							<xsd:annotation>
+								<xsd:documentation>The user_sid entity holds a string that represents the SID of a particular user.</xsd:documentation>
+							</xsd:annotation>
+						</xsd:element>
+						<xsd:element name="enabled" type="oval-def:EntityStateBoolType" minOccurs="0">
+							<xsd:annotation>
+								<xsd:documentation>This element holds a boolean value that specifies whether the particular user account is enabled or not.</xsd:documentation>
+							</xsd:annotation>
+						</xsd:element>
+						<xsd:element name="group_sid" type="oval-def:EntityStateStringType" minOccurs="0">
+							<xsd:annotation>
+								<xsd:documentation>A string the represents the SID of a particular group.  The group_sid element can be included multiple times in a system characteristic item in order to record that a user can be a member of a number of different groups. Note that the entity_check attribute associated with EntityStateStringType guides the evaluation of entities like group that refer to items that can occur an unbounded number of times.</xsd:documentation>
+							</xsd:annotation>
+						</xsd:element>
+						<xsd:element name="last_logon" type="oval-def:EntityStateIntType" minOccurs="0">
+							<xsd:annotation>
+								<xsd:documentation>The date and time when the last logon occurred. This value is stored as the number of seconds that have elapsed since 00:00:00, January 1, 1970, GMT.</xsd:documentation>
+							</xsd:annotation>
+						</xsd:element>
+						<xsd:element name="user" type="oval-def:EntityStateStringType" minOccurs="0">
 						   <xsd:annotation>
 								<xsd:documentation>A string the represents the name of a particular user. In Windows, user names are case-insensitive. As a result, it is recommended that the case-insensitive operations are used for this entity. In a domain environment, users should be identified in the form: "domain\user name". For local users use: "computer_name\user_name". For built-in accounts on the system, use the user name without a domain.</xsd:documentation>
 						   </xsd:annotation>
-					  </xsd:element>
-					  <xsd:element name="group" type="oval-def:EntityStateStringType" minOccurs="0">
+						</xsd:element>
+						<xsd:element name="group" type="oval-def:EntityStateStringType" minOccurs="0">
 						   <xsd:annotation>
 								<xsd:documentation>A string that represents the name of a particular group. In Windows, group names are case-insensitive. As a result, it is recommended that the case-insensitive operations are used for this entity. In a domain environment, groups should be identified in the form: "domain\group name". For local groups use: "computer name\group name". For built-in accounts on the system, use the group name without a domain.</xsd:documentation>
 								<xsd:documentation>If the specified user belongs to more than one group, then multiple group elements should exist. If the specified user is not a member of a single group, then a single group element should exist with a status of 'does not exist'. If there is an error determining the groups that the user belongs to, then a single group element should be included with a status of 'error'.</xsd:documentation>
 						   </xsd:annotation>
-					  </xsd:element>
+						</xsd:element>
+						<xsd:element name="full_name" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+						  <xsd:annotation>
+								<xsd:documentation>A Unicode string that contains the full name of the user. This string can be a NULL string, or it can have any number of characters before the terminating null character.</xsd:documentation>
+						  </xsd:annotation>
+						</xsd:element>
+						<xsd:element name="comment" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+						  <xsd:annotation>
+								<xsd:documentation>A Unicode string that contains a comment to associate with the user account. The string can be a NULL string, or it can have any number of characters before the terminating null character.</xsd:documentation>
+						  </xsd:annotation>
+						</xsd:element>
+						<xsd:element name="password_age_days" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+						  <xsd:annotation>
+								<xsd:documentation>The number of days that have elapsed since the password was last changed. This data should be rounded up to the nearest integer.</xsd:documentation>
+						  </xsd:annotation>
+						</xsd:element>
                     </xsd:sequence>
                 </xsd:extension>
             </xsd:complexContent>

--- a/oval-schemas/windows-definitions-schema.xsd
+++ b/oval-schemas/windows-definitions-schema.xsd
@@ -8145,12 +8145,12 @@
                                     </xsd:element>
                                     <xsd:element name="full_name" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
                                           <xsd:annotation>
-                                                <xsd:documentation>A Unicode string that contains the full name of the user. This string can be a NULL string, or it can have any number of characters before the terminating null character.</xsd:documentation>
+                                                <xsd:documentation>A string that contains the full name of the user.</xsd:documentation>
                                           </xsd:annotation>
                                     </xsd:element>
                                     <xsd:element name="comment" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
                                           <xsd:annotation>
-                                                <xsd:documentation>A Unicode string that contains a comment to associate with the user account. The string can be a NULL string, or it can have any number of characters before the terminating null character.</xsd:documentation>
+                                                <xsd:documentation>A string that contains a comment to associate with the user account.</xsd:documentation>
                                           </xsd:annotation>
                                     </xsd:element>
                                     <xsd:element name="password_age_days" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
@@ -8332,12 +8332,12 @@
 			</xsd:element>
 			<xsd:element name="full_name" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
 			  <xsd:annotation>
-					<xsd:documentation>A Unicode string that contains the full name of the user. This string can be a NULL string, or it can have any number of characters before the terminating null character.</xsd:documentation>
+					<xsd:documentation>A string that contains the full name of the user.</xsd:documentation>
 			  </xsd:annotation>
 			</xsd:element>
 			<xsd:element name="comment" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
 			  <xsd:annotation>
-					<xsd:documentation>A Unicode string that contains a comment to associate with the user account. The string can be a NULL string, or it can have any number of characters before the terminating null character.</xsd:documentation>
+					<xsd:documentation>A string that contains a comment to associate with the user account.</xsd:documentation>
 			  </xsd:annotation>
 			</xsd:element>
 			<xsd:element name="password_age_days" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">

--- a/oval-schemas/windows-definitions-schema.xsd
+++ b/oval-schemas/windows-definitions-schema.xsd
@@ -8155,7 +8155,7 @@
                                     </xsd:element>
                                     <xsd:element name="password_age_days" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
                                           <xsd:annotation>
-                                                <xsd:documentation>The number of days that have elapsed since the password was last changed. This data should be rounded up to the nearest integer.</xsd:documentation>
+                                                <xsd:documentation>The number of days that have elapsed since the password was last changed. This data should be rounded down to the nearest integer (floor function).</xsd:documentation>
                                           </xsd:annotation>
                                     </xsd:element>
                                     <xsd:element name="lockout" type="oval-def:EntityStateBoolType" minOccurs="0" maxOccurs="1">
@@ -8299,52 +8299,52 @@
             <xsd:complexContent>
                 <xsd:extension base="oval-def:StateType">
                     <xsd:sequence>
-						<xsd:element name="user_sid" type="oval-def:EntityStateStringType" minOccurs="0">
-							<xsd:annotation>
-								<xsd:documentation>The user_sid entity holds a string that represents the SID of a particular user.</xsd:documentation>
-							</xsd:annotation>
-						</xsd:element>
-						<xsd:element name="enabled" type="oval-def:EntityStateBoolType" minOccurs="0">
-							<xsd:annotation>
-								<xsd:documentation>This element holds a boolean value that specifies whether the particular user account is enabled or not.</xsd:documentation>
-							</xsd:annotation>
-						</xsd:element>
-						<xsd:element name="group_sid" type="oval-def:EntityStateStringType" minOccurs="0">
-							<xsd:annotation>
-								<xsd:documentation>A string the represents the SID of a particular group.  The group_sid element can be included multiple times in a system characteristic item in order to record that a user can be a member of a number of different groups. Note that the entity_check attribute associated with EntityStateStringType guides the evaluation of entities like group that refer to items that can occur an unbounded number of times.</xsd:documentation>
-							</xsd:annotation>
-						</xsd:element>
-						<xsd:element name="last_logon" type="oval-def:EntityStateIntType" minOccurs="0">
-							<xsd:annotation>
-								<xsd:documentation>The date and time when the last logon occurred. This value is stored as the number of seconds that have elapsed since 00:00:00, January 1, 1970, GMT.</xsd:documentation>
-							</xsd:annotation>
-						</xsd:element>
-						<xsd:element name="user" type="oval-def:EntityStateStringType" minOccurs="0">
-						   <xsd:annotation>
-								<xsd:documentation>A string the represents the name of a particular user. In Windows, user names are case-insensitive. As a result, it is recommended that the case-insensitive operations are used for this entity. In a domain environment, users should be identified in the form: "domain\user name". For local users use: "computer_name\user_name". For built-in accounts on the system, use the user name without a domain.</xsd:documentation>
-						   </xsd:annotation>
-						</xsd:element>
-						<xsd:element name="group" type="oval-def:EntityStateStringType" minOccurs="0">
-						   <xsd:annotation>
-								<xsd:documentation>A string that represents the name of a particular group. In Windows, group names are case-insensitive. As a result, it is recommended that the case-insensitive operations are used for this entity. In a domain environment, groups should be identified in the form: "domain\group name". For local groups use: "computer name\group name". For built-in accounts on the system, use the group name without a domain.</xsd:documentation>
-								<xsd:documentation>If the specified user belongs to more than one group, then multiple group elements should exist. If the specified user is not a member of a single group, then a single group element should exist with a status of 'does not exist'. If there is an error determining the groups that the user belongs to, then a single group element should be included with a status of 'error'.</xsd:documentation>
-						   </xsd:annotation>
-						</xsd:element>
-						<xsd:element name="full_name" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
-						  <xsd:annotation>
-								<xsd:documentation>A Unicode string that contains the full name of the user. This string can be a NULL string, or it can have any number of characters before the terminating null character.</xsd:documentation>
-						  </xsd:annotation>
-						</xsd:element>
-						<xsd:element name="comment" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
-						  <xsd:annotation>
-								<xsd:documentation>A Unicode string that contains a comment to associate with the user account. The string can be a NULL string, or it can have any number of characters before the terminating null character.</xsd:documentation>
-						  </xsd:annotation>
-						</xsd:element>
-						<xsd:element name="password_age_days" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
-						  <xsd:annotation>
-								<xsd:documentation>The number of days that have elapsed since the password was last changed. This data should be rounded up to the nearest integer.</xsd:documentation>
-						  </xsd:annotation>
-						</xsd:element>
+			<xsd:element name="user_sid" type="oval-def:EntityStateStringType" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>The user_sid entity holds a string that represents the SID of a particular user.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="enabled" type="oval-def:EntityStateBoolType" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>This element holds a boolean value that specifies whether the particular user account is enabled or not.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="group_sid" type="oval-def:EntityStateStringType" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>A string the represents the SID of a particular group.  The group_sid element can be included multiple times in a system characteristic item in order to record that a user can be a member of a number of different groups. Note that the entity_check attribute associated with EntityStateStringType guides the evaluation of entities like group that refer to items that can occur an unbounded number of times.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="last_logon" type="oval-def:EntityStateIntType" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>The date and time when the last logon occurred. This value is stored as the number of seconds that have elapsed since 00:00:00, January 1, 1970, GMT.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="user" type="oval-def:EntityStateStringType" minOccurs="0">
+			   <xsd:annotation>
+					<xsd:documentation>A string the represents the name of a particular user. In Windows, user names are case-insensitive. As a result, it is recommended that the case-insensitive operations are used for this entity. In a domain environment, users should be identified in the form: "domain\user name". For local users use: "computer_name\user_name". For built-in accounts on the system, use the user name without a domain.</xsd:documentation>
+			   </xsd:annotation>
+			</xsd:element>
+			<xsd:element name="group" type="oval-def:EntityStateStringType" minOccurs="0">
+			   <xsd:annotation>
+					<xsd:documentation>A string that represents the name of a particular group. In Windows, group names are case-insensitive. As a result, it is recommended that the case-insensitive operations are used for this entity. In a domain environment, groups should be identified in the form: "domain\group name". For local groups use: "computer name\group name". For built-in accounts on the system, use the group name without a domain.</xsd:documentation>
+					<xsd:documentation>If the specified user belongs to more than one group, then multiple group elements should exist. If the specified user is not a member of a single group, then a single group element should exist with a status of 'does not exist'. If there is an error determining the groups that the user belongs to, then a single group element should be included with a status of 'error'.</xsd:documentation>
+			   </xsd:annotation>
+			</xsd:element>
+			<xsd:element name="full_name" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+			  <xsd:annotation>
+					<xsd:documentation>A Unicode string that contains the full name of the user. This string can be a NULL string, or it can have any number of characters before the terminating null character.</xsd:documentation>
+			  </xsd:annotation>
+			</xsd:element>
+			<xsd:element name="comment" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+			  <xsd:annotation>
+					<xsd:documentation>A Unicode string that contains a comment to associate with the user account. The string can be a NULL string, or it can have any number of characters before the terminating null character.</xsd:documentation>
+			  </xsd:annotation>
+			</xsd:element>
+			<xsd:element name="password_age_days" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+			  <xsd:annotation>
+					<xsd:documentation>The number of full days that have elapsed since the password was last changed. This data should be rounded down to the nearest integer, (floor function).</xsd:documentation>
+			  </xsd:annotation>
+			</xsd:element>
                     </xsd:sequence>
                 </xsd:extension>
             </xsd:complexContent>

--- a/oval-schemas/windows-system-characteristics-schema.xsd
+++ b/oval-schemas/windows-system-characteristics-schema.xsd
@@ -3264,12 +3264,12 @@
                               </xsd:element>
                               <xsd:element name="full_name" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
                                    <xsd:annotation>
-                                        <xsd:documentation>A Unicode string that contains the full name of the user. This string can be a NULL string, or it can have any number of characters before the terminating null character.</xsd:documentation>
+                                        <xsd:documentation>A string that contains the full name of the user. </xsd:documentation>
                                    </xsd:annotation>
                               </xsd:element>
                               <xsd:element name="comment" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
                                    <xsd:annotation>
-                                        <xsd:documentation>A Unicode string that contains a comment to associate with the user account. The string can be a NULL string, or it can have any number of characters before the terminating null character.</xsd:documentation>
+                                        <xsd:documentation>A string that contains a comment to associate with the user account.</xsd:documentation>
                                    </xsd:annotation>
                               </xsd:element>
                               <xsd:element name="password_age_days" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
@@ -3381,12 +3381,12 @@
 				</xsd:element>
 				<xsd:element name="full_name" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
 				   <xsd:annotation>
-						<xsd:documentation>A Unicode string that contains the full name of the user. This string can be a NULL string, or it can have any number of characters before the terminating null character.</xsd:documentation>
+						<xsd:documentation>A string that contains the full name of the user. </xsd:documentation>
 				   </xsd:annotation>
 				</xsd:element>
 				<xsd:element name="comment" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
 				   <xsd:annotation>
-						<xsd:documentation>A Unicode string that contains a comment to associate with the user account. The string can be a NULL string, or it can have any number of characters before the terminating null character.</xsd:documentation>
+						<xsd:documentation>A string that contains a comment to associate with the user account.</xsd:documentation>
 				   </xsd:annotation>
 				</xsd:element>
 				<xsd:element name="password_age_days" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">

--- a/oval-schemas/windows-system-characteristics-schema.xsd
+++ b/oval-schemas/windows-system-characteristics-schema.xsd
@@ -3274,7 +3274,7 @@
                               </xsd:element>
                               <xsd:element name="password_age_days" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
                                    <xsd:annotation>
-                                        <xsd:documentation>The number of full days that have elapsed since the password was last changed, meaning data calculated should be truncated. Ex: 89.5 days = 89, 90.01 = 90</xsd:documentation>
+                                        <xsd:documentation>The number of full days that have elapsed since the password was last changed. This data should be rounded down to the nearest integer (floor function).</xsd:documentation>
                                    </xsd:annotation>
                               </xsd:element>
                               <xsd:element name="lockout" type="oval-sc:EntityItemBoolType" minOccurs="0" maxOccurs="1">
@@ -3348,52 +3348,52 @@
                   <xsd:complexContent>
                        <xsd:extension base="oval-sc:ItemType">
                              <xsd:sequence>
-                                   <xsd:element name="user_sid" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
-                                         <xsd:annotation>
-                                               <xsd:documentation>A string the represents the SID of a particular user.</xsd:documentation>
-                                         </xsd:annotation>
-                                   </xsd:element>
-                                   <xsd:element name="enabled" type="oval-sc:EntityItemBoolType" minOccurs="0" maxOccurs="1">
-                                         <xsd:annotation>
-                                               <xsd:documentation>A boolean that represents whether the particular user is enabled or not.</xsd:documentation>
-                                         </xsd:annotation>
-                                   </xsd:element>
-                                   <xsd:element name="group_sid" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="unbounded">
-                                         <xsd:annotation>
-                                               <xsd:documentation>A string that represents the SID of a particular group.  If the specified user belongs to more than one group, then multiple group_sid elements should exist. If the specified user is not a member of a single group, then a single group_sid element should exist with a status of 'does not exist'. If there is an error determining the groups that the user belongs to, then a single group_sid element should be included with a status of 'error'.</xsd:documentation>
-                                         </xsd:annotation>
-                                   </xsd:element>
-                                  <xsd:element name="last_logon" type="oval-sc:EntityItemIntType" minOccurs="0">
-                                       <xsd:annotation>
-                                            <xsd:documentation>The date and time when the last logon occurred. This value is stored as the number of seconds that have elapsed since 00:00:00, January 1, 1970, GMT.</xsd:documentation>
-                                       </xsd:annotation>
-                                  </xsd:element>
-								  <xsd:element name="user" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
-									   <xsd:annotation>
-											<xsd:documentation>A string the represents the name of a particular user. In Windows, user names are case-insensitive. As a result, it is recommended that the case-insensitive operations are used for this entity. In a domain environment, users should be identified in the form: "domain\user name". For local users use: "computer_name\user_name". For built-in accounts on the system, use the user name without a domain.</xsd:documentation>
-									   </xsd:annotation>
-								  </xsd:element>
-								  <xsd:element name="group" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="unbounded">
-									   <xsd:annotation>
-											<xsd:documentation>A string that represents the name of a particular group. In Windows, group names are case-insensitive. As a result, it is recommended that the case-insensitive operations are used for this entity. In a domain environment, groups should be identified in the form: "domain\group name". For local groups use: "computer name\group name". For built-in accounts on the system, use the group name without a domain.</xsd:documentation>
-											<xsd:documentation>If the specified user belongs to more than one group, then multiple group elements should exist. If the specified user is not a member of a single group, then a single group element should exist with a status of 'does not exist'. If there is an error determining the groups that the user belongs to, then a single group element should be included with a status of 'error'.</xsd:documentation>
-									   </xsd:annotation>
-								  </xsd:element>
-								  <xsd:element name="full_name" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
-									   <xsd:annotation>
-											<xsd:documentation>A Unicode string that contains the full name of the user. This string can be a NULL string, or it can have any number of characters before the terminating null character.</xsd:documentation>
-									   </xsd:annotation>
-								  </xsd:element>
-								  <xsd:element name="comment" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
-									   <xsd:annotation>
-											<xsd:documentation>A Unicode string that contains a comment to associate with the user account. The string can be a NULL string, or it can have any number of characters before the terminating null character.</xsd:documentation>
-									   </xsd:annotation>
-								  </xsd:element>
-								  <xsd:element name="password_age_days" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
-									   <xsd:annotation>
-											<xsd:documentation>The number of full days that have elapsed since the password was last changed, meaning data calulated should be truncated. Ex: 89.5 days = 89, 90.01 = 90</xsd:documentation>
-									   </xsd:annotation>
-                              </xsd:element>
+				<xsd:element name="user_sid" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+				 <xsd:annotation>
+				       <xsd:documentation>A string the represents the SID of a particular user.</xsd:documentation>
+				 </xsd:annotation>
+				</xsd:element>
+				<xsd:element name="enabled" type="oval-sc:EntityItemBoolType" minOccurs="0" maxOccurs="1">
+				 <xsd:annotation>
+				       <xsd:documentation>A boolean that represents whether the particular user is enabled or not.</xsd:documentation>
+				 </xsd:annotation>
+				</xsd:element>
+				<xsd:element name="group_sid" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="unbounded">
+				 <xsd:annotation>
+				       <xsd:documentation>A string that represents the SID of a particular group.  If the specified user belongs to more than one group, then multiple group_sid elements should exist. If the specified user is not a member of a single group, then a single group_sid element should exist with a status of 'does not exist'. If there is an error determining the groups that the user belongs to, then a single group_sid element should be included with a status of 'error'.</xsd:documentation>
+				 </xsd:annotation>
+				</xsd:element>
+				<xsd:element name="last_logon" type="oval-sc:EntityItemIntType" minOccurs="0">
+				<xsd:annotation>
+				    <xsd:documentation>The date and time when the last logon occurred. This value is stored as the number of seconds that have elapsed since 00:00:00, January 1, 1970, GMT.</xsd:documentation>
+				</xsd:annotation>
+				</xsd:element>
+				<xsd:element name="user" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+				   <xsd:annotation>
+						<xsd:documentation>A string the represents the name of a particular user. In Windows, user names are case-insensitive. As a result, it is recommended that the case-insensitive operations are used for this entity. In a domain environment, users should be identified in the form: "domain\user name". For local users use: "computer_name\user_name". For built-in accounts on the system, use the user name without a domain.</xsd:documentation>
+				   </xsd:annotation>
+				</xsd:element>
+				<xsd:element name="group" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="unbounded">
+				   <xsd:annotation>
+						<xsd:documentation>A string that represents the name of a particular group. In Windows, group names are case-insensitive. As a result, it is recommended that the case-insensitive operations are used for this entity. In a domain environment, groups should be identified in the form: "domain\group name". For local groups use: "computer name\group name". For built-in accounts on the system, use the group name without a domain.</xsd:documentation>
+						<xsd:documentation>If the specified user belongs to more than one group, then multiple group elements should exist. If the specified user is not a member of a single group, then a single group element should exist with a status of 'does not exist'. If there is an error determining the groups that the user belongs to, then a single group element should be included with a status of 'error'.</xsd:documentation>
+				   </xsd:annotation>
+				</xsd:element>
+				<xsd:element name="full_name" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+				   <xsd:annotation>
+						<xsd:documentation>A Unicode string that contains the full name of the user. This string can be a NULL string, or it can have any number of characters before the terminating null character.</xsd:documentation>
+				   </xsd:annotation>
+				</xsd:element>
+				<xsd:element name="comment" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+				   <xsd:annotation>
+						<xsd:documentation>A Unicode string that contains a comment to associate with the user account. The string can be a NULL string, or it can have any number of characters before the terminating null character.</xsd:documentation>
+				   </xsd:annotation>
+				</xsd:element>
+				<xsd:element name="password_age_days" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
+				   <xsd:annotation>
+						<xsd:documentation>The number of days that have elapsed since the password was last changed. This data should be rounded down to the nearest integer (floor function).</xsd:documentation>
+				   </xsd:annotation>
+				</xsd:element>
                              </xsd:sequence>
                        </xsd:extension>
                  </xsd:complexContent>

--- a/oval-schemas/windows-system-characteristics-schema.xsd
+++ b/oval-schemas/windows-system-characteristics-schema.xsd
@@ -3368,16 +3368,31 @@
                                             <xsd:documentation>The date and time when the last logon occurred. This value is stored as the number of seconds that have elapsed since 00:00:00, January 1, 1970, GMT.</xsd:documentation>
                                        </xsd:annotation>
                                   </xsd:element>
-                              <xsd:element name="user" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
-                                   <xsd:annotation>
-                                        <xsd:documentation>A string the represents the name of a particular user. In Windows, user names are case-insensitive. As a result, it is recommended that the case-insensitive operations are used for this entity. In a domain environment, users should be identified in the form: "domain\user name". For local users use: "computer_name\user_name". For built-in accounts on the system, use the user name without a domain.</xsd:documentation>
-                                   </xsd:annotation>
-                              </xsd:element>
-                              <xsd:element name="group" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="unbounded">
-                                   <xsd:annotation>
-                                        <xsd:documentation>A string that represents the name of a particular group. In Windows, group names are case-insensitive. As a result, it is recommended that the case-insensitive operations are used for this entity. In a domain environment, groups should be identified in the form: "domain\group name". For local groups use: "computer name\group name". For built-in accounts on the system, use the group name without a domain.</xsd:documentation>
-                                        <xsd:documentation>If the specified user belongs to more than one group, then multiple group elements should exist. If the specified user is not a member of a single group, then a single group element should exist with a status of 'does not exist'. If there is an error determining the groups that the user belongs to, then a single group element should be included with a status of 'error'.</xsd:documentation>
-                                   </xsd:annotation>
+								  <xsd:element name="user" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+									   <xsd:annotation>
+											<xsd:documentation>A string the represents the name of a particular user. In Windows, user names are case-insensitive. As a result, it is recommended that the case-insensitive operations are used for this entity. In a domain environment, users should be identified in the form: "domain\user name". For local users use: "computer_name\user_name". For built-in accounts on the system, use the user name without a domain.</xsd:documentation>
+									   </xsd:annotation>
+								  </xsd:element>
+								  <xsd:element name="group" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="unbounded">
+									   <xsd:annotation>
+											<xsd:documentation>A string that represents the name of a particular group. In Windows, group names are case-insensitive. As a result, it is recommended that the case-insensitive operations are used for this entity. In a domain environment, groups should be identified in the form: "domain\group name". For local groups use: "computer name\group name". For built-in accounts on the system, use the group name without a domain.</xsd:documentation>
+											<xsd:documentation>If the specified user belongs to more than one group, then multiple group elements should exist. If the specified user is not a member of a single group, then a single group element should exist with a status of 'does not exist'. If there is an error determining the groups that the user belongs to, then a single group element should be included with a status of 'error'.</xsd:documentation>
+									   </xsd:annotation>
+								  </xsd:element>
+								  <xsd:element name="full_name" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+									   <xsd:annotation>
+											<xsd:documentation>A Unicode string that contains the full name of the user. This string can be a NULL string, or it can have any number of characters before the terminating null character.</xsd:documentation>
+									   </xsd:annotation>
+								  </xsd:element>
+								  <xsd:element name="comment" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+									   <xsd:annotation>
+											<xsd:documentation>A Unicode string that contains a comment to associate with the user account. The string can be a NULL string, or it can have any number of characters before the terminating null character.</xsd:documentation>
+									   </xsd:annotation>
+								  </xsd:element>
+								  <xsd:element name="password_age_days" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
+									   <xsd:annotation>
+											<xsd:documentation>The number of full days that have elapsed since the password was last changed, meaning data calulated should be truncated. Ex: 89.5 days = 89, 90.01 = 90</xsd:documentation>
+									   </xsd:annotation>
                               </xsd:element>
                              </xsd:sequence>
                        </xsd:extension>


### PR DESCRIPTION
I've made a bit of a mess of this issue, accidentally committing it originally to master (back in March), then reverting and adding to the 6.0.1 dev branch, and now that OVAL 5.12.1 appears to be aligning with SCAP 1.4, I'm re-adding this update back to 5.12.1.  OVAL developers should still refrain from using the deprecated Windows 'user' test, so these new attributes on user_sid55 are still very useful, and will help the transition to 6.0 eventually.

This PR was originally reviewed and accepted by @solind, but I'd like another sanity check on it, as it will be going directly and intentionally into 'master' as I've already merged 5.12.1_dev into master.  