### PR TITLE
Update windows ntuser test to collect data related to the user having logged in via windows explorer per #306

### DIFF
--- a/oval-schemas/windows-definitions-schema.xsd
+++ b/oval-schemas/windows-definitions-schema.xsd
@@ -3931,6 +3931,8 @@
                   <xsd:documentation>The ntuser test is used to check metadata associated with Windows ntuser.dat files. It extends the standard TestType as defined in the oval-definitions-schema and
                         one should refer to the TestType description for more information. The required object element references a ntuser_object and the optional state element specifies the ntuser
                         data to check.</xsd:documentation>
+						
+						<xsd:documentation>To ensure consistent results across OVAL interpreters, application developers should refer to documentation in the ntuser_item when implenting this test.</xsd:documentation>
                   <xsd:appinfo>
                         <oval:element_mapping>
                               <oval:test>ntuser_test</oval:test>
@@ -4035,11 +4037,13 @@
                                     <xsd:element name="key" type="oval-def:EntityStateStringType" minOccurs="0">
                                           <xsd:annotation>
                                                 <xsd:documentation>This element describes a registry key normally found in the HKCU hive to be tested.</xsd:documentation>
+												<xsd:documentation>Note:  The key not existing on the target does not impact the overall existence of the ntuser_item.</xsd:documentation>
                                           </xsd:annotation>
                                     </xsd:element>
                                     <xsd:element name="name" type="oval-def:EntityStateStringType" minOccurs="0">
                                           <xsd:annotation>
                                                 <xsd:documentation>This element describes the name of a value of a registry key.</xsd:documentation>
+												<xsd:documentation>Note:  The name not existing on the target does not impact the overall existence of the ntuser_item.</xsd:documentation>
                                           </xsd:annotation>
                                     </xsd:element>
                                     <xsd:element name="sid" type="oval-def:EntityStateStringType" minOccurs="0">
@@ -4062,16 +4066,18 @@
                                     <xsd:element name="logged_on" type="oval-def:EntityStateBoolType" minOccurs="0">
                                           <xsd:annotation>
                                                 <xsd:documentation>The logged_on element describes if the user account is currently logged on to the computer.</xsd:documentation>
+												<xsd:documentation>This can be determined by comparing the SID’s against those populated in HKEY_USERS</xsd:documentation>
                                           </xsd:annotation>
                                     </xsd:element>
 								  <xsd:element name="days_since_last_logon" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
 									   <xsd:annotation>
-											<xsd:documentation>The last_logon data, converted to days and then rounded down to the nearest integer (floor function). If the account is determined to be currently logged in, this date should be reported as 0.</xsd:documentation>
+											<xsd:documentation>The last_logon data which can be obtained from the LocalProfileLoadTimeHigh and LocalProfileLoadTimeLow values, converted to days and then rounded down to the nearest integer (floor function). If the account is determined to be currently logged in, this date should be reported as 0.</xsd:documentation>
 									   </xsd:annotation>
 								  </xsd:element>
                                     <xsd:element name="enabled" type="oval-def:EntityStateBoolType" minOccurs="0">
                                           <xsd:annotation>
                                                 <xsd:documentation>The enabled element describes if the user account is enabled or disabled.</xsd:documentation>
+												<xsd:documentation>Note: For domain users, if a domain controller is not available, this will not return data.  If using this data for a filter to include enabled accounts, it’s recommended to exclude accounts that are have been determined to be disabled, vs including ones that are enabled, as the later may filter out accounts for which the domain controller could not return data.</xsd:documentation>
                                           </xsd:annotation>
                                     </xsd:element>
                                     <xsd:element name="date_modified" type="oval-def:EntityStateIntType" minOccurs="0">
@@ -4088,6 +4094,7 @@
                                     <xsd:element name="filepath" type="oval-def:EntityStateStringType" minOccurs="0">
                                           <xsd:annotation>
                                                 <xsd:documentation>This element describes the filepath of the ntuser.dat file.</xsd:documentation>
+												<xsd:documentation>The existance of each ntuser.dat file determines the overall ntuser_item existence.</xsd:documentation>
                                           </xsd:annotation>
                                     </xsd:element>
                                     <xsd:element name="last_write_time" type="oval-def:EntityStateIntType" minOccurs="0">

--- a/oval-schemas/windows-definitions-schema.xsd
+++ b/oval-schemas/windows-definitions-schema.xsd
@@ -4069,11 +4069,17 @@
 												<xsd:documentation>This can be determined by comparing the SID’s against those populated in HKEY_USERS</xsd:documentation>
                                           </xsd:annotation>
                                     </xsd:element>
-								  <xsd:element name="days_since_last_logon" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+									<xsd:element name="days_since_last_logon" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
 									   <xsd:annotation>
 											<xsd:documentation>The last_logon data which can be obtained from the LocalProfileLoadTimeHigh and LocalProfileLoadTimeLow values, converted to days and then rounded down to the nearest integer (floor function). If the account is determined to be currently logged in, this date should be reported as 0.</xsd:documentation>
 									   </xsd:annotation>
-								  </xsd:element>
+									</xsd:element>
+                                    <xsd:element name="user_has_signed_into_explorer" type="oval-def:EntityStateBoolType" minOccurs="0">
+                                          <xsd:annotation>
+                                                <xsd:documentation>The user_has_signed_into_explorer element describes if the user account has ever interactively logged into Windows Explorer.  This is important as User GPO's are applied when a user logs into Windows Explorer, and are not applied for non-interactive logins such as Ansible over SSH or Windows RM.  Those non-interactive logins may cause false positives, and content authors may want to filter them out.</xsd:documentation>
+												<xsd:documentation>This can be determined by gathering the Software\Microsoft\Windows\CurrentVersion\Explorer\UserSigned value for the given ntuser.dat profile, 1 = true and 0 = false.</xsd:documentation>
+                                          </xsd:annotation>
+                                    </xsd:element>
                                     <xsd:element name="enabled" type="oval-def:EntityStateBoolType" minOccurs="0">
                                           <xsd:annotation>
                                                 <xsd:documentation>The enabled element describes if the user account is enabled or disabled.</xsd:documentation>

--- a/oval-schemas/windows-definitions-schema.xsd
+++ b/oval-schemas/windows-definitions-schema.xsd
@@ -4076,7 +4076,7 @@
 									</xsd:element>
                                     <xsd:element name="user_has_signed_into_explorer" type="oval-def:EntityStateBoolType" minOccurs="0">
                                           <xsd:annotation>
-                                                <xsd:documentation>The user_has_signed_into_explorer element describes if the user account has ever interactively logged into Windows Explorer.  This is important as User GPO's are applied when a user logs into Windows Explorer, and are not applied for non-interactive logins such as Ansible over SSH or Windows RM.  Those non-interactive logins may cause false positives, and content authors may want to filter them out.</xsd:documentation>
+                                                <xsd:documentation>The user_has_signed_into_explorer element describes if the user account has ever interactively logged into Windows Explorer.  This is important as User GPO's are applied when a user logs into Windows Explorer, and are not applied for non-interactive logins such as SSH or WinRM.  Those non-interactive logins may cause false positives, and content authors may want to filter them out.</xsd:documentation>
 												<xsd:documentation>This can be determined by gathering the Software\Microsoft\Windows\CurrentVersion\Explorer\UserSigned value for the given ntuser.dat profile, 1 = true and 0 = false.</xsd:documentation>
                                           </xsd:annotation>
                                     </xsd:element>

--- a/oval-schemas/windows-system-characteristics-schema.xsd
+++ b/oval-schemas/windows-system-characteristics-schema.xsd
@@ -1695,7 +1695,7 @@
                               </xsd:element>
 								<xsd:element name="user_has_signed_into_explorer" type="oval-def:EntityItemBoolType" minOccurs="0">
 									<xsd:annotation>
-										<xsd:documentation>The user_has_signed_into_explorer element describes if the user account has ever interactively logged into Windows Explorer.  This is important as User GPO's are applied when a user logs into Windows Explorer, and are not applied for non-interactive logins such as Ansible over SSH or Windows RM.  Those non-interactive logins may cause false positives, and content authors may want to filter them out.</xsd:documentation>
+										<xsd:documentation>The user_has_signed_into_explorer element describes if the user account has ever interactively logged into Windows Explorer.  This is important as User GPO's are applied when a user logs into Windows Explorer, and are not applied for non-interactive logins such as SSH or WinRM.  Those non-interactive logins may cause false positives, and content authors may want to filter them out.</xsd:documentation>
 										<xsd:documentation>This can be determined by gathering the Software\Microsoft\Windows\CurrentVersion\Explorer\UserSigned value for the given ntuser.dat profile, 1 = true and 0 = false.</xsd:documentation>
 									</xsd:annotation>
 								</xsd:element>							  

--- a/oval-schemas/windows-system-characteristics-schema.xsd
+++ b/oval-schemas/windows-system-characteristics-schema.xsd
@@ -1692,7 +1692,13 @@
                                    <xsd:annotation>
                                         <xsd:documentation>The last_logon data, which can be obtained from the LocalProfileLoadTimeHigh and LocalProfileLoadTimeLow values, converted to days and then rounded down to the nearest integer (floor function). If the account is determined to be currently logged in, this date should be reported as 0.</xsd:documentation>
                                    </xsd:annotation>
-                              </xsd:element>							  
+                              </xsd:element>
+								<xsd:element name="user_has_signed_into_explorer" type="oval-def:EntityItemBoolType" minOccurs="0">
+									<xsd:annotation>
+										<xsd:documentation>The user_has_signed_into_explorer element describes if the user account has ever interactively logged into Windows Explorer.  This is important as User GPO's are applied when a user logs into Windows Explorer, and are not applied for non-interactive logins such as Ansible over SSH or Windows RM.  Those non-interactive logins may cause false positives, and content authors may want to filter them out.</xsd:documentation>
+										<xsd:documentation>This can be determined by gathering the Software\Microsoft\Windows\CurrentVersion\Explorer\UserSigned value for the given ntuser.dat profile, 1 = true and 0 = false.</xsd:documentation>
+									</xsd:annotation>
+								</xsd:element>							  
                               <xsd:element name="enabled" type="oval-sc:EntityItemBoolType" minOccurs="0" maxOccurs="1">
                                    <xsd:annotation>
                                         <xsd:documentation>The enabled element describes if the user account is enabled or disabled.</xsd:documentation>

--- a/oval-schemas/windows-system-characteristics-schema.xsd
+++ b/oval-schemas/windows-system-characteristics-schema.xsd
@@ -1629,6 +1629,22 @@
      <xsd:element name="ntuser_item" substitutionGroup="oval-sc:item">
           <xsd:annotation>
                <xsd:documentation>The windows ntuser_item specifies information that can be collected from a particular ntuser.dat file.</xsd:documentation>
+<xsd:documentation>To ensure consistent results across OVAL interpreters, the following implementation methods are recommended.  Note that there may be other technical ways to obtain the data, which vendors may choose to implement.</xsd:documentation>
+<xsd:documentation>1.	Finding Human User Profiles </xsd:documentation>
+<xsd:documentation>	 a.	Obtain a list of User Profiles from the following registry key, where each subkey is a profile that may be included in scope for this test</xsd:documentation>
+<xsd:documentation>		i.	HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\WindowsNT\CurrentVersion\ProfileList</xsd:documentation>
+<xsd:documentation>	 b.	Determine which user profiles are from ‘human’ users</xsd:documentation>
+<xsd:documentation>		i.	Exclude profiles for LocalService, Network service etc.. by excluding subkeys in the format of S-1-5-&lt;number*gt;</xsd:documentation>
+<xsd:documentation>		ii.	Exclude profiles for Per-Service SIDs by excluding subkeys in the format of S-1-5-80-&lt;number*gt;-&lt;number*gt;-&lt;number*gt;-&lt;number*gt;-&lt;number*gt;</xsd:documentation>
+<xsd:documentation>		iii. Include Local and Domain User SIDs by including subkeys match the format of S-1-5-21-&lt;number*gt;-&lt;number*gt;-&lt;number*gt;-&lt;number*gt;</xsd:documentation>
+<xsd:documentation>	 c.	Obtain ntuser filepath from the ProfileImagePath value of 'human' profiles</xsd:documentation>
+<xsd:documentation>2.	Creating ntuser items</xsd:documentation>
+<xsd:documentation>If the filepath obtained from the ProfileImagePath exists on the target system, create a ntuser_item with a status of 'exists'</xsd:documentation>
+<xsd:documentation>3.	Gathering per user registry key data</xsd:documentation>
+<xsd:documentation>	a.	If a user is logged in, their ntuser.dat file will be locked and the OVAL interpreter will not be able to read it, the OVAL interpreter will need to obtain that data from HKEY_USERS\&lt;sid_of_logged_in_user&gt;</xsd:documentation>
+<xsd:documentation>	b.	If a user is not logged in, the OVAL interpreter will need to obtain the data directly from the users ntuser.dat file.</xsd:documentation>
+<xsd:documentation>	Note: There are many different methods depenending on programming language to parse ntuser.dat files, and each OVAL interpreter may choose their own methods.</xsd:documentation>
+<xsd:documentation>	If no other programming language native methods are available, it is advised not to load the ntuser.dat file directly from its original location, as it will lock the file and prevent that user from logging into Windows.  The file will need to be copied/renamed to a temporary location and then loaded, used and unloaded and removed.</xsd:documentation>
           </xsd:annotation>
           <xsd:complexType>
                <xsd:complexContent>
@@ -1637,6 +1653,7 @@
                               <xsd:element name="key" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
                                    <xsd:annotation>
                                         <xsd:documentation>This element describes a registry key normally found in the HKCU hive to be tested.</xsd:documentation>
+										<xsd:documentation>Note:  The key not existing does not impact the overall existence of the ntuser_item.</xsd:documentation>
                                    </xsd:annotation>
                               </xsd:element>
                               <xsd:element name="name" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1" nillable="true">
@@ -1644,6 +1661,7 @@
                                         <xsd:documentation>This element describes the name of a registry key. If the xsi:nil attribute is set to true, then the item being represented is the
                                              higher level key. Using xsi:nil here will result in a status of 'does not exist' for the type, and value entities since these entities are not
                                              associated with a key by itself.</xsd:documentation>
+										<xsd:documentation>Note:  The name not existing does not impact the overall existence of the ntuser_item.</xsd:documentation>
                                    </xsd:annotation>
                               </xsd:element>
                               <xsd:element name="sid" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
@@ -1656,6 +1674,7 @@
                                         <xsd:documentation>The username entity holds a string that represents the name of a particular user. In Windows, user names are case-insensitive. As a
                                              result, it is recommended that the case-insensitive operations are used for this entity. In a domain environment, users should be identified in
                                              the form: "domain\user name". For local users use: "computer name\user name".</xsd:documentation>
+										<xsd:documentation>Note: When gathering the built-in Guest and build-in Administrator, they may not resolve and may need to have the ComputerName prepended to it.</xsd:documentation>
                                    </xsd:annotation>
                               </xsd:element>
                               <xsd:element name="account_type" type="win-sc:EntityItemNTUserAccountTypeType" minOccurs="0" maxOccurs="1">
@@ -1666,16 +1685,18 @@
                               <xsd:element name="logged_on" type="oval-sc:EntityItemBoolType" minOccurs="0" maxOccurs="1">
                                    <xsd:annotation>
                                         <xsd:documentation>The logged_on element describes if the user account is currently logged on to the computer.</xsd:documentation>
+										<xsd:documentation>This can be determined by comparing the SIDs collected from the ProfileList against those populated in HKEY_USERS</xsd:documentation>
                                    </xsd:annotation>
                               </xsd:element>
                               <xsd:element name="days_since_last_logon" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
                                    <xsd:annotation>
-                                        <xsd:documentation>The last_logon data, converted to days and then rounded down to the nearest integer (floor function). If the account is determined to be currently logged in, this date should be reported as 0.</xsd:documentation>
+                                        <xsd:documentation>The last_logon data, which can be obtained from the LocalProfileLoadTimeHigh and LocalProfileLoadTimeLow values, converted to days and then rounded down to the nearest integer (floor function). If the account is determined to be currently logged in, this date should be reported as 0.</xsd:documentation>
                                    </xsd:annotation>
                               </xsd:element>							  
                               <xsd:element name="enabled" type="oval-sc:EntityItemBoolType" minOccurs="0" maxOccurs="1">
                                    <xsd:annotation>
                                         <xsd:documentation>The enabled element describes if the user account is enabled or disabled.</xsd:documentation>
+										<xsd:documentation>Note: For domain users, if a domain controller is not available, this will not return data.  If using this data for a filter to include enabled accounts, it’s recommended to exclude accounts that are have been determined to be disabled, vs including ones that are enabled, as the later may filter out accounts for which the domain controller could not return data.</xsd:documentation>
                                    </xsd:annotation>
                               </xsd:element>
                               <xsd:element name="date_modified" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
@@ -1692,6 +1713,7 @@
                               <xsd:element name="filepath" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
                                    <xsd:annotation>
                                         <xsd:documentation>This element describes the filepath of the ntuser.dat file.</xsd:documentation>
+										<xsd:documentation>The existance of each ntuser.dat file determines the overall ntuser_item existence.</xsd:documentation>
                                    </xsd:annotation>
                               </xsd:element>
                               <xsd:element name="last_write_time" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">


### PR DESCRIPTION
Added element which can be used to filter out users that have not logged into Windows Explorer, and have been known to create false positives for ntuser checks that look at GPO registry keys, that are not applied to users who have never logged into Windows Explorer.