### PR TITLE
Deprecating obsolete xinetd and runlevel tests per #309 and #304

### DIFF
--- a/oval-schemas/unix-definitions-schema.xsd
+++ b/oval-schemas/unix-definitions-schema.xsd
@@ -1736,6 +1736,17 @@
                         </oval:element_mapping>
                   </xsd:appinfo>
                   <xsd:appinfo>
+                        <oval:deprecated_info>
+                              <oval:version>5.12.3</oval:version>
+                              <oval:reason>The runlevel_test has been deprecated because runlevel is obsolete.  The runlevel_test may be removed in a future version of the language.</oval:reason>
+                        </oval:deprecated_info>
+                        <sch:pattern id="unix-def_runleveltst_dep">
+                              <sch:rule context="unix-def:runlevel_test">
+                                    <sch:report test="true()">DEPRECATED TEST: <sch:value-of select="name()"/> ID: <sch:value-of select="@id"/></sch:report>
+                              </sch:rule>
+                        </sch:pattern>
+                  </xsd:appinfo>
+                  <xsd:appinfo>
                         <sch:pattern id="unix-def_runleveltst">
                               <sch:rule context="unix-def:runlevel_test/unix-def:object">
                                     <sch:assert test="@object_ref=ancestor::oval-def:oval_definitions/oval-def:objects/unix-def:runlevel_object/@id"><sch:value-of select="../@id"/> - the object child element of a runlevel_test must reference a runlevel_object</sch:assert>
@@ -2699,6 +2710,19 @@
                               <oval:item target_namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#unix">xinetd_item</oval:item>
                         </oval:element_mapping>
                   </xsd:appinfo>
+				  
+                  <xsd:appinfo>
+                        <oval:deprecated_info>
+                              <oval:version>5.12.3</oval:version>
+                              <oval:reason>The xinetd_test has been deprecated because xinetd is obsolete.  The xinetd_test may be removed in a future version of the language.</oval:reason>
+                        </oval:deprecated_info>
+                        <sch:pattern id="unix-def_xinetttst_dep">
+                              <sch:rule context="unix-def:xinetd_test">
+                                    <sch:report test="true()">DEPRECATED TEST: <sch:value-of select="name()"/> ID: <sch:value-of select="@id"/></sch:report>
+                              </sch:rule>
+                        </sch:pattern>
+                  </xsd:appinfo>
+				  
                   <xsd:appinfo>
                         <sch:pattern id="unix-def_xinetdtst">
                               <sch:rule context="unix-def:xinetd_test/unix-def:object">

--- a/oval-schemas/unix-system-characteristics-schema.xsd
+++ b/oval-schemas/unix-system-characteristics-schema.xsd
@@ -761,7 +761,20 @@
      <xsd:element name="runlevel_item" substitutionGroup="oval-sc:item">
           <xsd:annotation>
                <xsd:documentation>The runlevel item holds information about the start or kill state of a specified service at a given runlevel. Each runlevel item contains service name and runlevel information as well as start and kill information. It extends the standard ItemType as defined in the oval-system-characteristics schema and one should refer to the ItemType description for more information.</xsd:documentation>
-          </xsd:annotation>
+          
+		        <xsd:appinfo>
+                    <oval:deprecated_info>
+                         <oval:version>5.12.3</oval:version>
+                         <oval:reason>The runlevel_item has been deprecated because runlevel is obsolete.  The runlevel_item may be removed in a future version of the language.</oval:reason>
+                    </oval:deprecated_info>
+                    <sch:pattern id="unix-sc_runlevelitem_dep">
+                         <sch:rule context="unix-sc:runlevel_item">
+                              <sch:report test="true()">DEPRECATED ITEM: <sch:value-of select="name()"/> ID: <sch:value-of select="@id"/></sch:report>
+                         </sch:rule>
+                    </sch:pattern>
+               </xsd:appinfo>
+		  
+		  </xsd:annotation>
           <xsd:complexType>
                <xsd:complexContent>
                     <xsd:extension base="oval-sc:ItemType">
@@ -1177,7 +1190,20 @@
      <xsd:element name="xinetd_item" substitutionGroup="oval-sc:item">
           <xsd:annotation>
                <xsd:documentation>The xinetd item holds information associated with different Internet services. It extends the standard ItemType as defined in the oval-system-characteristics schema and one should refer to the ItemType description for more information.</xsd:documentation>
-          </xsd:annotation>
+          
+		        <xsd:appinfo>
+                    <oval:deprecated_info>
+                         <oval:version>5.12.3</oval:version>
+                         <oval:reason>The xinetd_item has been deprecated because xinetd is obsolete.  The xinetd_item may be removed in a future version of the language.</oval:reason>
+                    </oval:deprecated_info>
+                    <sch:pattern id="unix-sc_xinetditem_dep">
+                         <sch:rule context="unix-sc:xinetd_item">
+                              <sch:report test="true()">DEPRECATED ITEM: <sch:value-of select="name()"/> ID: <sch:value-of select="@id"/></sch:report>
+                         </sch:rule>
+                    </sch:pattern>
+               </xsd:appinfo>
+		  		  
+		  </xsd:annotation>
           <xsd:complexType>
                <xsd:complexContent>
                     <xsd:extension base="oval-sc:ItemType">


### PR DESCRIPTION
Per recent oval board meetings discussing the creation of SCAP 1.4 test content, both xinetd and runlevel were deemed obsolete.