### PR TITLE
Deprecating unused File recurse_direction of 'up' per #317

### DIFF
--- a/oval-schemas/independent-definitions-schema.xsd
+++ b/oval-schemas/independent-definitions-schema.xsd
@@ -2632,6 +2632,15 @@ SERVERPROPERTY('IsClustered') AS [is_clustered]
                         <xsd:restriction base="xsd:string">
                               <xsd:enumeration value="none"/>
                               <xsd:enumeration value="up"/>
+								<xsd:annotation>
+										<xsd:appinfo>
+											<oval:deprecated_info>
+												<oval:version>5.12.3</oval:version>
+												<oval:reason>The value of 'up' is being removed because it is unused in the language and adds unneeded complexity to OVAL Interpreters.</oval:reason>
+												<oval:comment>These values have been deprecated and will be removed in version 6.0.1 of the language.</oval:comment>
+											</oval:deprecated_info>
+										</xsd:appinfo>
+									</xsd:annotation>
                               <xsd:enumeration value="down"/>
                         </xsd:restriction>
                   </xsd:simpleType>

--- a/oval-schemas/unix-definitions-schema.xsd
+++ b/oval-schemas/unix-definitions-schema.xsd
@@ -547,7 +547,7 @@
 										<oval:deprecated_info>
 											<oval:version>5.12.3</oval:version>
 											<oval:reason>The value of 'up' is being removed because it is unused in the language and adds unneeded complexity to OVAL Interpreters.</oval:reason>
-											<oval:comment>These values have been deprecated and will be removed in version 6.0 of the language.</oval:comment>
+											<oval:comment>These values have been deprecated and will be removed in version 6.0.1 of the language.</oval:comment>
 										</oval:deprecated_info>
 									</xsd:appinfo>
 								</xsd:annotation>

--- a/oval-schemas/unix-definitions-schema.xsd
+++ b/oval-schemas/unix-definitions-schema.xsd
@@ -542,6 +542,15 @@
                         <xsd:restriction base="xsd:string">
                               <xsd:enumeration value="none"/>
                               <xsd:enumeration value="up"/>
+								<xsd:annotation>
+									<xsd:appinfo>
+										<oval:deprecated_info>
+											<oval:version>5.12.3</oval:version>
+											<oval:reason>The value of 'up' is being removed because it is unused in the language and adds unneeded complexity to OVAL Interpreters.</oval:reason>
+											<oval:comment>These values have been deprecated and will be removed in version 6.0 of the language.</oval:comment>
+										</oval:deprecated_info>
+									</xsd:appinfo>
+								</xsd:annotation>
                               <xsd:enumeration value="down"/>
                         </xsd:restriction>
                   </xsd:simpleType>

--- a/oval-schemas/windows-definitions-schema.xsd
+++ b/oval-schemas/windows-definitions-schema.xsd
@@ -1857,7 +1857,7 @@
 										<oval:deprecated_info>
 											<oval:version>5.12.3</oval:version>
 											<oval:reason>The value of 'up' is being removed because it is unused in the language and adds unneeded complexity to OVAL Interpreters.</oval:reason>
-											<oval:comment>These values have been deprecated and will be removed in version 6.0 of the language.</oval:comment>
+											<oval:comment>These values have been deprecated and will be removed in version 6.0.1 of the language.</oval:comment>
 										</oval:deprecated_info>
 									</xsd:appinfo>
 								</xsd:annotation>

--- a/oval-schemas/windows-definitions-schema.xsd
+++ b/oval-schemas/windows-definitions-schema.xsd
@@ -1852,6 +1852,15 @@
                         <xsd:restriction base="xsd:string">
                               <xsd:enumeration value="none"/>
                               <xsd:enumeration value="up"/>
+								<xsd:annotation>
+									<xsd:appinfo>
+										<oval:deprecated_info>
+											<oval:version>5.12.3</oval:version>
+											<oval:reason>The value of 'up' is being removed because it is unused in the language and adds unneeded complexity to OVAL Interpreters.</oval:reason>
+											<oval:comment>These values have been deprecated and will be removed in version 6.0 of the language.</oval:comment>
+										</oval:deprecated_info>
+									</xsd:appinfo>
+								</xsd:annotation>
                               <xsd:enumeration value="down"/>
                         </xsd:restriction>
                   </xsd:simpleType>


### PR DESCRIPTION
This feature has been unused since the start of OVAL and just adds unneeded complexity to OVAL interpreters.  Marking as deprecated.   Can be un-deprecated if some valid use case is documented that warrants it's usage.