### PR TITLE
Added new 'user_has_signed_into_explorer' element to ntuser state/item per #306

### DIFF
--- a/oval-schemas/windows-definitions-schema.xsd
+++ b/oval-schemas/windows-definitions-schema.xsd
@@ -4086,7 +4086,7 @@
 								  </xsd:element>
 								    <xsd:element name="user_has_signed_into_explorer" type="oval-def:EntityStateBoolType" minOccurs="0">
                                           <xsd:annotation>
-                                                <xsd:documentation>The user_has_signed_into_explorer element describes if the user account has ever interactively logged into Windows Explorer.  This is important as User GPO's are applied when a user logs into Windows Explorer, and are not applied for non-interactive logins such as SSH or WinRM.  Those non-interactive logins may cause false positives, and content authors may want to filter them out.</xsd:documentation>
+                                                <xsd:documentation>The user_has_signed_into_explorer element describes if the user account has ever run Windows Explorer. This is a practical indicator of accounts using interactive (desktop/GUI) sessions and is not set by non-interactive logon methods such as WinRM or SSH. Content authors may use this element to exclude non-interactive users from user policy checks.</xsd:documentation>
 												<xsd:documentation>This can be determined by gathering the Software\Microsoft\Windows\CurrentVersion\Explorer\UserSigned value for the given ntuser.dat profile, 1 = true and 0 = false.</xsd:documentation>
                                           </xsd:annotation>
                                     </xsd:element>

--- a/oval-schemas/windows-definitions-schema.xsd
+++ b/oval-schemas/windows-definitions-schema.xsd
@@ -4086,7 +4086,7 @@
 								  </xsd:element>
 								    <xsd:element name="user_has_signed_into_explorer" type="oval-def:EntityStateBoolType" minOccurs="0">
                                           <xsd:annotation>
-                                                <xsd:documentation>The user_has_signed_into_explorer element describes if the user account has ever run Windows Explorer. This is a practical indicator of accounts using interactive (desktop/GUI) sessions and is not set by non-interactive logon methods such as WinRM or SSH. Content authors may use this element to exclude non-interactive users from user policy checks.</xsd:documentation>
+                                                <xsd:documentation>The user_has_signed_into_explorer element describes if the user account has ever executed explorer.exe. This is a practical indicator of accounts using interactive (desktop/GUI) sessions and is not set by non-interactive logon methods such as WinRM or SSH. Content authors may use this element to exclude non-interactive users from user policy checks.</xsd:documentation>
 												<xsd:documentation>This can be determined by gathering the Software\Microsoft\Windows\CurrentVersion\Explorer\UserSigned value for the given ntuser.dat profile, 1 = true and 0 = false.</xsd:documentation>
                                           </xsd:annotation>
                                     </xsd:element>

--- a/oval-schemas/windows-definitions-schema.xsd
+++ b/oval-schemas/windows-definitions-schema.xsd
@@ -4069,6 +4069,12 @@
 											<xsd:documentation>The last_logon data, converted to days and then rounded down to the nearest integer (floor function). If the account is determined to be currently logged in, this date should be reported as 0.</xsd:documentation>
 									   </xsd:annotation>
 								  </xsd:element>
+								    <xsd:element name="user_has_signed_into_explorer" type="oval-def:EntityStateBoolType" minOccurs="0">
+                                          <xsd:annotation>
+                                                <xsd:documentation>The user_has_signed_into_explorer element describes if the user account has ever interactively logged into Windows Explorer.  This is important as User GPO's are applied when a user logs into Windows Explorer, and are not applied for non-interactive logins such as SSH or WinRM.  Those non-interactive logins may cause false positives, and content authors may want to filter them out.</xsd:documentation>
+												<xsd:documentation>This can be determined by gathering the Software\Microsoft\Windows\CurrentVersion\Explorer\UserSigned value for the given ntuser.dat profile, 1 = true and 0 = false.</xsd:documentation>
+                                          </xsd:annotation>
+                                    </xsd:element>
                                     <xsd:element name="enabled" type="oval-def:EntityStateBoolType" minOccurs="0">
                                           <xsd:annotation>
                                                 <xsd:documentation>The enabled element describes if the user account is enabled or disabled.</xsd:documentation>

--- a/oval-schemas/windows-system-characteristics-schema.xsd
+++ b/oval-schemas/windows-system-characteristics-schema.xsd
@@ -1693,7 +1693,7 @@
                               </xsd:element>	
 							<xsd:element name="user_has_signed_into_explorer" type="oval-sc:EntityItemBoolType" minOccurs="0" maxOccurs="1">
 								<xsd:annotation>
-									<xsd:documentation>The user_has_signed_into_explorer element describes if the user account has ever interactively logged into Windows Explorer.  This is important as User GPO's are applied when a user logs into Windows Explorer, and are not applied for non-interactive logins such as SSH or WinRM.  Those non-interactive logins may cause false positives, and content authors may want to filter them out.</xsd:documentation>
+									<xsd:documentation>The user_has_signed_into_explorer element describes if the user account has ever run Windows Explorer. This is a practical indicator of accounts using interactive (desktop/GUI) sessions and is not set by non-interactive logon methods such as WinRM or SSH. Content authors may use this element to exclude non-interactive users from user policy checks.</xsd:documentation>
 									<xsd:documentation>This can be determined by gathering the Software\Microsoft\Windows\CurrentVersion\Explorer\UserSigned value for the given ntuser.dat profile, 1 = true and 0 = false.</xsd:documentation>
 								</xsd:annotation>
 							</xsd:element>							  

--- a/oval-schemas/windows-system-characteristics-schema.xsd
+++ b/oval-schemas/windows-system-characteristics-schema.xsd
@@ -1693,7 +1693,7 @@
                               </xsd:element>	
 							<xsd:element name="user_has_signed_into_explorer" type="oval-sc:EntityItemBoolType" minOccurs="0" maxOccurs="1">
 								<xsd:annotation>
-									<xsd:documentation>The user_has_signed_into_explorer element describes if the user account has ever run Windows Explorer. This is a practical indicator of accounts using interactive (desktop/GUI) sessions and is not set by non-interactive logon methods such as WinRM or SSH. Content authors may use this element to exclude non-interactive users from user policy checks.</xsd:documentation>
+									<xsd:documentation>The user_has_signed_into_explorer element describes if the user account has ever executed explorer.exe. This is a practical indicator of accounts using interactive (desktop/GUI) sessions and is not set by non-interactive logon methods such as WinRM or SSH. Content authors may use this element to exclude non-interactive users from user policy checks.</xsd:documentation>
 									<xsd:documentation>This can be determined by gathering the Software\Microsoft\Windows\CurrentVersion\Explorer\UserSigned value for the given ntuser.dat profile, 1 = true and 0 = false.</xsd:documentation>
 								</xsd:annotation>
 							</xsd:element>							  

--- a/oval-schemas/windows-system-characteristics-schema.xsd
+++ b/oval-schemas/windows-system-characteristics-schema.xsd
@@ -1672,7 +1672,13 @@
                                    <xsd:annotation>
                                         <xsd:documentation>The last_logon data, converted to days and then rounded down to the nearest integer (floor function). If the account is determined to be currently logged in, this date should be reported as 0.</xsd:documentation>
                                    </xsd:annotation>
-                              </xsd:element>							  
+                              </xsd:element>
+							<xsd:element name="user_has_signed_into_explorer" type="oval-sc:EntityItemBoolType" minOccurs="0" maxOccurs="1">
+								<xsd:annotation>
+									<xsd:documentation>The user_has_signed_into_explorer element describes if the user account has ever interactively logged into Windows Explorer.  This is important as User GPO's are applied when a user logs into Windows Explorer, and are not applied for non-interactive logins such as SSH or WinRM.  Those non-interactive logins may cause false positives, and content authors may want to filter them out.</xsd:documentation>
+									<xsd:documentation>This can be determined by gathering the Software\Microsoft\Windows\CurrentVersion\Explorer\UserSigned value for the given ntuser.dat profile, 1 = true and 0 = false.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:element>							  
                               <xsd:element name="enabled" type="oval-sc:EntityItemBoolType" minOccurs="0" maxOccurs="1">
                                    <xsd:annotation>
                                         <xsd:documentation>The enabled element describes if the user account is enabled or disabled.</xsd:documentation>

--- a/oval-schemas/windows-system-characteristics-schema.xsd
+++ b/oval-schemas/windows-system-characteristics-schema.xsd
@@ -1666,13 +1666,17 @@
                               <xsd:element name="logged_on" type="oval-sc:EntityItemBoolType" minOccurs="0" maxOccurs="1">
                                    <xsd:annotation>
                                         <xsd:documentation>The logged_on element describes if the user account is currently logged on to the computer.</xsd:documentation>
-                                   </xsd:annotation>
+										<xsd:documentation>This can be determined by comparing the SIDs collected from the ProfileList against those populated in HKEY_USERS\&lt;SID&gt;</xsd:documentation>
+										<xsd:documentation>HKEY_USERS: Contains all the actively loaded user profiles on the computer.  https://learn.microsoft.com/en-us/troubleshoot/windows-server/performance/windows-registry-advanced-users</xsd:documentation>
+										<xsd:documentation>This data can also be obtained by other various Windows API's such as a combination of win32_logonsession and win32_loggedonuser, but the specifics are beyond the scope of OVAL documentation.</xsd:documentation>
+								   </xsd:annotation>
                               </xsd:element>
                               <xsd:element name="days_since_last_logon" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
-                                   <xsd:annotation>
-                                        <xsd:documentation>The last_logon data, converted to days and then rounded down to the nearest integer (floor function). If the account is determined to be currently logged in, this date should be reported as 0.</xsd:documentation>
-                                   </xsd:annotation>
-                              </xsd:element>
+								   <xsd:annotation>
+										<xsd:documentation>The last_logon data which can be obtained from the LocalProfileLoadTimeHigh and LocalProfileLoadTimeLow registry values from HKLM\Software\Microsoft\Windows NT\CurrentVersion\ProfileList\&lt;SID&gt;, converted to days and then rounded down to the nearest integer (floor function). If the account is determined to be currently logged in, this date should be reported as 0.</xsd:documentation>
+										<xsd:documentation>For more information, refer to https://learn.microsoft.com/en-us/troubleshoot/windows-server/support-tools/scripts-to-retrieve-profile-age</xsd:documentation>
+								   </xsd:annotation>
+                              </xsd:element>	
 							<xsd:element name="user_has_signed_into_explorer" type="oval-sc:EntityItemBoolType" minOccurs="0" maxOccurs="1">
 								<xsd:annotation>
 									<xsd:documentation>The user_has_signed_into_explorer element describes if the user account has ever interactively logged into Windows Explorer.  This is important as User GPO's are applied when a user logs into Windows Explorer, and are not applied for non-interactive logins such as SSH or WinRM.  Those non-interactive logins may cause false positives, and content authors may want to filter them out.</xsd:documentation>
@@ -1682,6 +1686,7 @@
                               <xsd:element name="enabled" type="oval-sc:EntityItemBoolType" minOccurs="0" maxOccurs="1">
                                    <xsd:annotation>
                                         <xsd:documentation>The enabled element describes if the user account is enabled or disabled.</xsd:documentation>
+										<xsd:documentation>Note: For domain users, if a domain controller is not available, this will not return data, and should be reported with a status of 'not collected'.  If using this data for a filter to include enabled accounts, it’s recommended to exclude accounts that are have been determined to be disabled, vs including ones that are enabled, as the later may filter out accounts for which the domain controller could not return data.</xsd:documentation>
                                    </xsd:annotation>
                               </xsd:element>
                               <xsd:element name="date_modified" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">


### PR DESCRIPTION
Added new element to state/item which allows content authors to filter out users that have not logged in interactively and can be a source of false negatives, as this partial profile does not receive GPO's