### PR TITLE
Deprecated recurse_direction of 'up' for Windows registry and ntuser tests per #320

### DIFF
--- a/oval-schemas/windows-definitions-schema.xsd
+++ b/oval-schemas/windows-definitions-schema.xsd
@@ -4169,7 +4169,7 @@
 										<oval:deprecated_info>
 											<oval:version>5.12.3</oval:version>
 											<oval:reason>The value of 'up' is being removed because it is unused in the language and adds unneeded complexity to OVAL Interpreters.</oval:reason>
-											<oval:comment>These values have been deprecated and will be removed in version 6.0 of the language.</oval:comment>
+											<oval:comment>These values have been deprecated and will be removed in version 6.0.1 of the language.</oval:comment>
 										</oval:deprecated_info>
 									</xsd:appinfo>
 								</xsd:annotation>
@@ -5537,7 +5537,7 @@
 										<oval:deprecated_info>
 											<oval:version>5.12.3</oval:version>
 											<oval:reason>The value of 'up' is being removed because it is unused in the language and adds unneeded complexity to OVAL Interpreters.</oval:reason>
-											<oval:comment>These values have been deprecated and will be removed in version 6.0 of the language.</oval:comment>
+											<oval:comment>These values have been deprecated and will be removed in version 6.0.1 of the language.</oval:comment>
 										</oval:deprecated_info>
 									</xsd:appinfo>
 								</xsd:annotation>

--- a/oval-schemas/windows-definitions-schema.xsd
+++ b/oval-schemas/windows-definitions-schema.xsd
@@ -4164,6 +4164,15 @@
                         <xsd:restriction base="xsd:string">
                               <xsd:enumeration value="none"/>
                               <xsd:enumeration value="up"/>
+							  	<xsd:annotation>
+									<xsd:appinfo>
+										<oval:deprecated_info>
+											<oval:version>5.12.3</oval:version>
+											<oval:reason>The value of 'up' is being removed because it is unused in the language and adds unneeded complexity to OVAL Interpreters.</oval:reason>
+											<oval:comment>These values have been deprecated and will be removed in version 6.0 of the language.</oval:comment>
+										</oval:deprecated_info>
+									</xsd:appinfo>
+								</xsd:annotation>
                               <xsd:enumeration value="down"/>
                         </xsd:restriction>
                   </xsd:simpleType>
@@ -5523,6 +5532,15 @@
                         <xsd:restriction base="xsd:string">
                               <xsd:enumeration value="none"/>
                               <xsd:enumeration value="up"/>
+							  	<xsd:annotation>
+									<xsd:appinfo>
+										<oval:deprecated_info>
+											<oval:version>5.12.3</oval:version>
+											<oval:reason>The value of 'up' is being removed because it is unused in the language and adds unneeded complexity to OVAL Interpreters.</oval:reason>
+											<oval:comment>These values have been deprecated and will be removed in version 6.0 of the language.</oval:comment>
+										</oval:deprecated_info>
+									</xsd:appinfo>
+								</xsd:annotation>
                               <xsd:enumeration value="down"/>
                         </xsd:restriction>
                   </xsd:simpleType>


### PR DESCRIPTION
Deprecating an unused feature that only exists in educational content.  This just adds complexity to OVAL interpreters.  