### PR TITLE
Fixed typo in draft 5.12.3 schemas on the deprecation of up

### DIFF
--- a/oval-schemas/independent-definitions-schema.xsd
+++ b/oval-schemas/independent-definitions-schema.xsd
@@ -2646,16 +2646,17 @@ SERVERPROPERTY('IsClustered') AS [is_clustered]
                   <xsd:simpleType>
                         <xsd:restriction base="xsd:string">
                               <xsd:enumeration value="none"/>
-                              <xsd:enumeration value="up"/>
-								<xsd:annotation>
-										<xsd:appinfo>
-											<oval:deprecated_info>
-												<oval:version>5.12.3</oval:version>
-												<oval:reason>The value of 'up' is being removed because it is unused in the language and adds unneeded complexity to OVAL Interpreters.</oval:reason>
-												<oval:comment>These values have been deprecated and will be removed in version 6.0.1 of the language.</oval:comment>
-											</oval:deprecated_info>
-										</xsd:appinfo>
-									</xsd:annotation>
+                              <xsd:enumeration value="up">
+                              <xsd:annotation>
+                                    <xsd:appinfo>
+                                        <oval:deprecated_info>
+                                            <oval:version>5.12.3</oval:version>
+                                            <oval:reason>The value of 'up' is being removed because it is unused in the language and adds unneeded complexity to OVAL Interpreters.</oval:reason>
+                                            <oval:comment>These values have been deprecated and will be removed in version 6.0.1 of the language.</oval:comment>
+                                        </oval:deprecated_info>
+                                    </xsd:appinfo>
+                                </xsd:annotation>
+                              </xsd:enumeration>
                               <xsd:enumeration value="down"/>
                         </xsd:restriction>
                   </xsd:simpleType>

--- a/oval-schemas/unix-definitions-schema.xsd
+++ b/oval-schemas/unix-definitions-schema.xsd
@@ -541,7 +541,7 @@
                   <xsd:simpleType>
                         <xsd:restriction base="xsd:string">
                               <xsd:enumeration value="none"/>
-                              <xsd:enumeration value="up"/>
+                              <xsd:enumeration value="up">
 								<xsd:annotation>
 									<xsd:appinfo>
 										<oval:deprecated_info>
@@ -551,6 +551,7 @@
 										</oval:deprecated_info>
 									</xsd:appinfo>
 								</xsd:annotation>
+                              </xsd:enumeration>
                               <xsd:enumeration value="down"/>
                         </xsd:restriction>
                   </xsd:simpleType>

--- a/oval-schemas/windows-definitions-schema.xsd
+++ b/oval-schemas/windows-definitions-schema.xsd
@@ -1851,7 +1851,7 @@
                   <xsd:simpleType>
                         <xsd:restriction base="xsd:string">
                               <xsd:enumeration value="none"/>
-                              <xsd:enumeration value="up"/>
+                              <xsd:enumeration value="up">
 								<xsd:annotation>
 									<xsd:appinfo>
 										<oval:deprecated_info>
@@ -1861,6 +1861,7 @@
 										</oval:deprecated_info>
 									</xsd:appinfo>
 								</xsd:annotation>
+                              </xsd:enumeration>
                               <xsd:enumeration value="down"/>
                         </xsd:restriction>
                   </xsd:simpleType>
@@ -4179,8 +4180,8 @@
                   <xsd:simpleType>
                         <xsd:restriction base="xsd:string">
                               <xsd:enumeration value="none"/>
-                              <xsd:enumeration value="up"/>
-							  	<xsd:annotation>
+                              <xsd:enumeration value="up">
+								<xsd:annotation>
 									<xsd:appinfo>
 										<oval:deprecated_info>
 											<oval:version>5.12.3</oval:version>
@@ -4189,6 +4190,7 @@
 										</oval:deprecated_info>
 									</xsd:appinfo>
 								</xsd:annotation>
+                              </xsd:enumeration>
                               <xsd:enumeration value="down"/>
                         </xsd:restriction>
                   </xsd:simpleType>
@@ -5561,8 +5563,8 @@
                   <xsd:simpleType>
                         <xsd:restriction base="xsd:string">
                               <xsd:enumeration value="none"/>
-                              <xsd:enumeration value="up"/>
-							  	<xsd:annotation>
+                              <xsd:enumeration value="up">
+								<xsd:annotation>
 									<xsd:appinfo>
 										<oval:deprecated_info>
 											<oval:version>5.12.3</oval:version>
@@ -5571,6 +5573,7 @@
 										</oval:deprecated_info>
 									</xsd:appinfo>
 								</xsd:annotation>
+                              </xsd:enumeration>
                               <xsd:enumeration value="down"/>
                         </xsd:restriction>
                   </xsd:simpleType>


### PR DESCRIPTION
Just need to fix the close tag on the up enumeration to be after the deprecation annotation.