### PR TITLE
Deprecated the 'windows_view' element and attribute per #329

### DIFF
--- a/oval-schemas/independent-definitions-schema.xsd
+++ b/oval-schemas/independent-definitions-schema.xsd
@@ -264,7 +264,14 @@
                                     <xsd:element name="windows_view" type="ind-def:EntityStateWindowsViewType" minOccurs="0">
                                           <xsd:annotation>
                                                 <xsd:documentation>The windows view value to which this was targeted. This is used to indicate which view (32-bit or 64-bit), the associated State applies to.  This entity only applies to 64-bit Microsoft Windows operating systems.</xsd:documentation>
-                                          </xsd:annotation>
+												<xsd:appinfo>
+													<oval:deprecated_info>
+														<oval:version>5.12.3</oval:version>
+														<oval:reason>Unused in production content and adds unneeded complexity to OVAL interpeters.  The equivalent data can be obtained by other existing OVAL methods.</oval:reason>
+														<oval:comment>This element has been deprecated and will be removed in version 6.0.1 of the language.</oval:comment>
+													</oval:deprecated_info>
+												</xsd:appinfo>
+										  </xsd:annotation>
                                     </xsd:element>
                               </xsd:sequence>
                         </xsd:extension>
@@ -432,7 +439,14 @@
                                     <xsd:element name="windows_view" type="ind-def:EntityStateWindowsViewType" minOccurs="0">
                                           <xsd:annotation>
                                                 <xsd:documentation>The windows view value to which this was targeted. This is used to indicate which view (32-bit or 64-bit), the associated State applies to.  This entity only applies to 64-bit Microsoft Windows operating systems.</xsd:documentation>
-                                          </xsd:annotation>
+												<xsd:appinfo>
+													<oval:deprecated_info>
+														<oval:version>5.12.3</oval:version>
+														<oval:reason>Unused in production content and adds unneeded complexity to OVAL interpeters.  The equivalent data can be obtained by other existing OVAL methods.</oval:reason>
+														<oval:comment>This element has been deprecated and will be removed in version 6.0.1 of the language.</oval:comment>
+													</oval:deprecated_info>
+												</xsd:appinfo>
+										  </xsd:annotation>
                                     </xsd:element>
                               </xsd:sequence>
                         </xsd:extension>
@@ -1901,7 +1915,14 @@ SERVERPROPERTY('IsClustered') AS [is_clustered]
                                     <xsd:element name="windows_view" type="ind-def:EntityStateWindowsViewType" minOccurs="0">
                                           <xsd:annotation>
                                                 <xsd:documentation>The windows view value to which this was targeted. This is used to indicate which view (32-bit or 64-bit), the associated State applies to.  This entity only applies to 64-bit Microsoft Windows operating systems.</xsd:documentation>
-                                          </xsd:annotation>
+												<xsd:appinfo>
+													<oval:deprecated_info>
+														<oval:version>5.12.3</oval:version>
+														<oval:reason>Unused in production content and adds unneeded complexity to OVAL interpeters.  The equivalent data can be obtained by other existing OVAL methods.</oval:reason>
+														<oval:comment>This element has been deprecated and will be removed in version 6.0.1 of the language.</oval:comment>
+													</oval:deprecated_info>
+												</xsd:appinfo>
+										  </xsd:annotation>
                                     </xsd:element>
                               </xsd:sequence>
                         </xsd:extension>
@@ -2086,7 +2107,14 @@ SERVERPROPERTY('IsClustered') AS [is_clustered]
                                     <xsd:element name="windows_view" type="ind-def:EntityStateWindowsViewType" minOccurs="0">
                                           <xsd:annotation>
                                                 <xsd:documentation>The windows view value to which this was targeted. This is used to indicate which view (32-bit or 64-bit), the associated State applies to.  This entity only applies to 64-bit Microsoft Windows operating systems.</xsd:documentation>
-                                          </xsd:annotation>
+												<xsd:appinfo>
+													<oval:deprecated_info>
+														<oval:version>5.12.3</oval:version>
+														<oval:reason>Unused in production content and adds unneeded complexity to OVAL interpeters.  The equivalent data can be obtained by other existing OVAL methods.</oval:reason>
+														<oval:comment>This element has been deprecated and will be removed in version 6.0.1 of the language.</oval:comment>
+													</oval:deprecated_info>
+												</xsd:appinfo>
+										  </xsd:annotation>
                                     </xsd:element>
                               </xsd:sequence>
                         </xsd:extension>
@@ -2395,7 +2423,14 @@ SERVERPROPERTY('IsClustered') AS [is_clustered]
                                     <xsd:element name="windows_view" type="ind-def:EntityStateWindowsViewType" minOccurs="0">
                                           <xsd:annotation>
                                                 <xsd:documentation>The windows view value to which this was targeted. This is used to indicate which view (32-bit or 64-bit), the associated State applies to.  This entity only applies to 64-bit Microsoft Windows operating systems.</xsd:documentation>
-                                          </xsd:annotation>
+												<xsd:appinfo>
+													<oval:deprecated_info>
+														<oval:version>5.12.3</oval:version>
+														<oval:reason>Unused in production content and adds unneeded complexity to OVAL interpeters.  The equivalent data can be obtained by other existing OVAL methods.</oval:reason>
+														<oval:comment>This element has been deprecated and will be removed in version 6.0.1 of the language.</oval:comment>
+													</oval:deprecated_info>
+												</xsd:appinfo>
+										  </xsd:annotation>
                                     </xsd:element>
                               </xsd:sequence>
                         </xsd:extension>
@@ -2597,7 +2632,14 @@ SERVERPROPERTY('IsClustered') AS [is_clustered]
                                     <xsd:element name="windows_view" type="ind-def:EntityStateWindowsViewType" minOccurs="0">
                                           <xsd:annotation>
                                                 <xsd:documentation>The windows view value to which this was targeted. This is used to indicate which view (32-bit or 64-bit), the associated State applies to.  This entity only applies to 64-bit Microsoft Windows operating systems.</xsd:documentation>
-                                          </xsd:annotation>
+												<xsd:appinfo>
+													<oval:deprecated_info>
+														<oval:version>5.12.3</oval:version>
+														<oval:reason>Unused in production content and adds unneeded complexity to OVAL interpeters.  The equivalent data can be obtained by other existing OVAL methods.</oval:reason>
+														<oval:comment>This element has been deprecated and will be removed in version 6.0.1 of the language.</oval:comment>
+													</oval:deprecated_info>
+												</xsd:appinfo>
+										  </xsd:annotation>
                                     </xsd:element>
                               </xsd:sequence>
                         </xsd:extension>
@@ -2678,7 +2720,14 @@ SERVERPROPERTY('IsClustered') AS [is_clustered]
                   <xsd:annotation>
                         <xsd:documentation>64-bit versions of Windows provide an alternate file system and registry views to 32-bit applications. This behavior allows the OVAL Object to specify which view should be examined. This behavior only applies to 64-bit Windows, and must not be applied on other platforms.</xsd:documentation>
                         <xsd:documentation>Note that the values have the following meaning: '64_bit' – Indicates that the 64-bit view on 64-bit Windows operating systems must be examined. On a 32-bit system, the Object must be evaluated without applying the behavior. '32_bit' – Indicates that the 32-bit view must be examined. On a 32-bit system, the Object must be evaluated without applying the behavior. It is recommended that the corresponding 'windows_view' entity be set on the OVAL Items that are collected when this behavior is used to distinguish between the OVAL Items that are collected in the 32-bit or 64-bit views.</xsd:documentation>
-                  </xsd:annotation>
+						<xsd:appinfo>
+							<oval:deprecated_info>
+								<oval:version>5.12.3</oval:version>
+								<oval:reason>Unused in production content and adds unneeded complexity to OVAL interpeters.  The equivalent data can be obtained by other existing OVAL methods.</oval:reason>
+								<oval:comment>This attribute has been deprecated and will be removed in version 6.0.1 of the language.</oval:comment>
+							</oval:deprecated_info>
+						</xsd:appinfo>
+				  </xsd:annotation>
                   <xsd:simpleType>
                         <xsd:restriction base="xsd:string">
                               <xsd:enumeration value="32_bit"/>

--- a/oval-schemas/independent-system-characteristics-schema.xsd
+++ b/oval-schemas/independent-system-characteristics-schema.xsd
@@ -92,7 +92,14 @@
                               <xsd:element name="windows_view" type="ind-sc:EntityItemWindowsViewType" minOccurs="0">
                                    <xsd:annotation>
                                         <xsd:documentation>The windows view value from which this OVAL Item was collected. This is used to indicate from which view (32-bit or 64-bit), the associated Item was collected. A value of '32_bit' indicates the Item was collected from the 32-bit view.  A value of '64-bit' indicates the Item was collected from the 64-bit view. Omitting this entity removes any assertion about which view the Item was collected from, and therefore it is strongly suggested that this entity be set. This entity only applies to 64-bit Microsoft Windows operating systems.</xsd:documentation>
-                                   </xsd:annotation>
+										<xsd:appinfo>
+											<oval:deprecated_info>
+												<oval:version>5.12.3</oval:version>
+												<oval:reason>Unused in production content and adds unneeded complexity to OVAL interpeters.  The equivalent data can be obtained by other existing OVAL methods.</oval:reason>
+												<oval:comment>This element has been deprecated and will be removed in version 6.0.1 of the language.</oval:comment>
+											</oval:deprecated_info>
+										</xsd:appinfo>
+								   </xsd:annotation>
                               </xsd:element>
                          </xsd:sequence>
                     </xsd:extension>
@@ -138,7 +145,14 @@
                               <xsd:element name="windows_view" type="ind-sc:EntityItemWindowsViewType" minOccurs="0">
                                    <xsd:annotation>
                                         <xsd:documentation>The windows view value from which this OVAL Item was collected. This is used to indicate from which view (32-bit or 64-bit), the associated Item was collected. A value of '32_bit' indicates the Item was collected from the 32-bit view.  A value of '64-bit' indicates the Item was collected from the 64-bit view. Omitting this entity removes any assertion about which view the Item was collected from, and therefore it is strongly suggested that this entity be set. This entity only applies to 64-bit Microsoft Windows operating systems.</xsd:documentation>
-                                   </xsd:annotation>
+										<xsd:appinfo>
+											<oval:deprecated_info>
+												<oval:version>5.12.3</oval:version>
+												<oval:reason>Unused in production content and adds unneeded complexity to OVAL interpeters.  The equivalent data can be obtained by other existing OVAL methods.</oval:reason>
+												<oval:comment>This element has been deprecated and will be removed in version 6.0.1 of the language.</oval:comment>
+											</oval:deprecated_info>
+										</xsd:appinfo>
+								   </xsd:annotation>
                               </xsd:element>
                          </xsd:sequence>
                     </xsd:extension>
@@ -623,7 +637,14 @@ The evaluation of the object should always produce one item.  If the object eval
                               <xsd:element name="windows_view" type="ind-sc:EntityItemWindowsViewType" minOccurs="0">
                                    <xsd:annotation>
                                         <xsd:documentation>The windows view value from which this OVAL Item was collected. This is used to indicate from which view (32-bit or 64-bit), the associated Item was collected. A value of '32_bit' indicates the Item was collected from the 32-bit view.  A value of '64-bit' indicates the Item was collected from the 64-bit view. Omitting this entity removes any assertion about which view the Item was collected from, and therefore it is strongly suggested that this entity be set. This entity only applies to 64-bit Microsoft Windows operating systems.</xsd:documentation>
-                                   </xsd:annotation>
+										<xsd:appinfo>
+											<oval:deprecated_info>
+												<oval:version>5.12.3</oval:version>
+												<oval:reason>Unused in production content and adds unneeded complexity to OVAL interpeters.  The equivalent data can be obtained by other existing OVAL methods.</oval:reason>
+												<oval:comment>This element has been deprecated and will be removed in version 6.0.1 of the language.</oval:comment>
+											</oval:deprecated_info>
+										</xsd:appinfo>
+								   </xsd:annotation>
                               </xsd:element>
                          </xsd:sequence>
                     </xsd:extension>
@@ -695,7 +716,14 @@ The evaluation of the object should always produce one item.  If the object eval
                               <xsd:element name="windows_view" type="ind-sc:EntityItemWindowsViewType" minOccurs="0">
                                    <xsd:annotation>
                                         <xsd:documentation>The windows view value from which this OVAL Item was collected. This is used to indicate from which view (32-bit or 64-bit), the associated Item was collected. A value of '32_bit' indicates the Item was collected from the 32-bit view.  A value of '64-bit' indicates the Item was collected from the 64-bit view. Omitting this entity removes any assertion about which view the Item was collected from, and therefore it is strongly suggested that this entity be set. This entity only applies to 64-bit Microsoft Windows operating systems.</xsd:documentation>
-                                   </xsd:annotation>
+										<xsd:appinfo>
+											<oval:deprecated_info>
+												<oval:version>5.12.3</oval:version>
+												<oval:reason>Unused in production content and adds unneeded complexity to OVAL interpeters.  The equivalent data can be obtained by other existing OVAL methods.</oval:reason>
+												<oval:comment>This element has been deprecated and will be removed in version 6.0.1 of the language.</oval:comment>
+											</oval:deprecated_info>
+										</xsd:appinfo>
+								   </xsd:annotation>
                               </xsd:element>
                          </xsd:sequence>
                     </xsd:extension>
@@ -753,7 +781,14 @@ The evaluation of the object should always produce one item.  If the object eval
                               <xsd:element name="windows_view" type="ind-sc:EntityItemWindowsViewType" minOccurs="0">
                                    <xsd:annotation>
                                         <xsd:documentation>The windows view value from which this OVAL Item was collected. This is used to indicate from which view (32-bit or 64-bit), the associated Item was collected. A value of '32_bit' indicates the Item was collected from the 32-bit view. A value of '64-bit' indicates the Item was collected from the 64-bit view. Omitting this entity removes any assertion about which view the Item was collected from, and therefore it is strongly suggested that this entity be set. This entity only applies to 64-bit Microsoft Windows operating systems.</xsd:documentation>
-                                   </xsd:annotation>
+										<xsd:appinfo>
+											<oval:deprecated_info>
+												<oval:version>5.12.3</oval:version>
+												<oval:reason>Unused in production content and adds unneeded complexity to OVAL interpeters.  The equivalent data can be obtained by other existing OVAL methods.</oval:reason>
+												<oval:comment>This element has been deprecated and will be removed in version 6.0.1 of the language.</oval:comment>
+											</oval:deprecated_info>
+										</xsd:appinfo>
+								   </xsd:annotation>
                               </xsd:element>
                          </xsd:sequence>
                     </xsd:extension>

--- a/oval-schemas/windows-definitions-schema.xsd
+++ b/oval-schemas/windows-definitions-schema.xsd
@@ -1805,7 +1805,14 @@
                                     <xsd:element name="windows_view" type="win-def:EntityStateWindowsViewType" minOccurs="0">
                                           <xsd:annotation>
                                                 <xsd:documentation>The windows view value to which this was targeted. This is used to indicate which view (32-bit or 64-bit), the associated State applies to.</xsd:documentation>
-                                          </xsd:annotation>
+												<xsd:appinfo>
+													<oval:deprecated_info>
+														<oval:version>5.12.3</oval:version>
+														<oval:reason>Unused in production content and adds unneeded complexity to OVAL interpeters.  The equivalent data can be obtained by other existing OVAL methods.</oval:reason>
+														<oval:comment>This element has been deprecated and will be removed in version 6.0.1 of the language.</oval:comment>
+													</oval:deprecated_info>
+												</xsd:appinfo>
+										  </xsd:annotation>
                                     </xsd:element>
                               </xsd:sequence>
                         </xsd:extension>
@@ -1883,7 +1890,14 @@
                   <xsd:annotation>
                         <xsd:documentation>64-bit versions of Windows provide an alternate file system and registry views to 32-bit applications. This behavior allows the OVAL Object to state which view should be examined. This behavior only applies to 64-bit Windows, and must not be applied on other platforms. </xsd:documentation>
                         <xsd:documentation>Note that the values have the following meaning: '64_bit' - Indicates that the 64-bit view on 64-bit Windows operating systems must be examined. On a 32-bit system, the Object must be evaluated without applying the behavior. '32_bit' - Indicates that the 32-bit view must be examined. On a 32-bit system, the Object must be evaluated without applying the behavior. It is recommended that the corresponding 'windows_view' entity be set on the OVAL Items that are collected when this behavior is used to distinguish between OVAL Items that were collected in the 32-bit or 64-bit views.</xsd:documentation>
-                  </xsd:annotation>
+						<xsd:appinfo>
+							<oval:deprecated_info>
+								<oval:version>5.12.3</oval:version>
+								<oval:reason>Unused in production content and adds unneeded complexity to OVAL interpeters.  The equivalent data can be obtained by other existing OVAL methods.</oval:reason>
+								<oval:comment>This attribute has been deprecated and will be removed in version 6.0.1 of the language.</oval:comment>
+							</oval:deprecated_info>
+						</xsd:appinfo>
+				  </xsd:annotation>
                   <xsd:simpleType>
                         <xsd:restriction base="xsd:string">
                               <xsd:enumeration value="32_bit"/>
@@ -2161,7 +2175,14 @@
                                     <xsd:element name="windows_view" type="win-def:EntityStateWindowsViewType" minOccurs="0">
                                           <xsd:annotation>
                                                 <xsd:documentation>The windows view value to which this was targeted. This is used to indicate which view (32-bit or 64-bit), the associated State applies to.</xsd:documentation>
-                                          </xsd:annotation>
+												<xsd:appinfo>
+													<oval:deprecated_info>
+														<oval:version>5.12.3</oval:version>
+														<oval:reason>Unused in production content and adds unneeded complexity to OVAL interpeters.  The equivalent data can be obtained by other existing OVAL methods.</oval:reason>
+														<oval:comment>This element has been deprecated and will be removed in version 6.0.1 of the language.</oval:comment>
+													</oval:deprecated_info>
+												</xsd:appinfo>
+										  </xsd:annotation>
                                     </xsd:element>
                               </xsd:sequence>
                         </xsd:extension>
@@ -2456,7 +2477,14 @@
                                     <xsd:element name="windows_view" type="win-def:EntityStateWindowsViewType" minOccurs="0">
                                           <xsd:annotation>
                                                 <xsd:documentation>The windows view value to which this was targeted. This is used to indicate which view (32-bit or 64-bit), the associated State applies to.</xsd:documentation>
-                                          </xsd:annotation>
+												<xsd:appinfo>
+													<oval:deprecated_info>
+														<oval:version>5.12.3</oval:version>
+														<oval:reason>Unused in production content and adds unneeded complexity to OVAL interpeters.  The equivalent data can be obtained by other existing OVAL methods.</oval:reason>
+														<oval:comment>This element has been deprecated and will be removed in version 6.0.1 of the language.</oval:comment>
+													</oval:deprecated_info>
+												</xsd:appinfo>
+										  </xsd:annotation>
                                     </xsd:element>
                               </xsd:sequence>
                         </xsd:extension>
@@ -2777,7 +2805,14 @@
                                     <xsd:element name="windows_view" type="win-def:EntityStateWindowsViewType" minOccurs="0">
                                           <xsd:annotation>
                                                 <xsd:documentation>The windows view value to which this was targeted. This is used to indicate which view (32-bit or 64-bit), the associated State applies to.</xsd:documentation>
-                                          </xsd:annotation>
+												<xsd:appinfo>
+													<oval:deprecated_info>
+														<oval:version>5.12.3</oval:version>
+														<oval:reason>Unused in production content and adds unneeded complexity to OVAL interpeters.  The equivalent data can be obtained by other existing OVAL methods.</oval:reason>
+														<oval:comment>This element has been deprecated and will be removed in version 6.0.1 of the language.</oval:comment>
+													</oval:deprecated_info>
+												</xsd:appinfo>
+										  </xsd:annotation>
                                     </xsd:element>
                               </xsd:sequence>
                         </xsd:extension>
@@ -3072,7 +3107,14 @@
                                     <xsd:element name="windows_view" type="win-def:EntityStateWindowsViewType" minOccurs="0">
                                           <xsd:annotation>
                                                 <xsd:documentation>The windows view value to which this was targeted. This is used to indicate which view (32-bit or 64-bit), the associated State applies to.</xsd:documentation>
-                                          </xsd:annotation>
+												<xsd:appinfo>
+													<oval:deprecated_info>
+														<oval:version>5.12.3</oval:version>
+														<oval:reason>Unused in production content and adds unneeded complexity to OVAL interpeters.  The equivalent data can be obtained by other existing OVAL methods.</oval:reason>
+														<oval:comment>This element has been deprecated and will be removed in version 6.0.1 of the language.</oval:comment>
+													</oval:deprecated_info>
+												</xsd:appinfo>
+										  </xsd:annotation>
                                     </xsd:element>
                               </xsd:sequence>
                         </xsd:extension>
@@ -3628,7 +3670,14 @@
                                     <xsd:element name="windows_view" type="win-def:EntityStateWindowsViewType" minOccurs="0">
                                           <xsd:annotation>
                                                 <xsd:documentation>The windows view value to which this was targeted. This is used to indicate which view (32-bit or 64-bit), the associated State applies to.</xsd:documentation>
-                                          </xsd:annotation>
+												<xsd:appinfo>
+													<oval:deprecated_info>
+														<oval:version>5.12.3</oval:version>
+														<oval:reason>Unused in production content and adds unneeded complexity to OVAL interpeters.  The equivalent data can be obtained by other existing OVAL methods.</oval:reason>
+														<oval:comment>This element has been deprecated and will be removed in version 6.0.1 of the language.</oval:comment>
+													</oval:deprecated_info>
+												</xsd:appinfo>
+										  </xsd:annotation>
                                     </xsd:element>
                               </xsd:sequence>
                         </xsd:extension>
@@ -4203,7 +4252,14 @@
                               system, the Object must be evaluated without applying the behavior. '32_bit' – Indicates that the 32-bit view must be examined. On a 32-bit system, the Object must be
                               evaluated without applying the behavior. It is recommended that the corresponding 'windows_view' entity be set on the OVAL Items that are collected when this behavior is
                               used to distinguish between the OVAL Items that are collected in the 32-bit or 64-bit views.</xsd:documentation>
-                  </xsd:annotation>
+						<xsd:appinfo>
+							<oval:deprecated_info>
+								<oval:version>5.12.3</oval:version>
+								<oval:reason>Unused in production content and adds unneeded complexity to OVAL interpeters.  The equivalent data can be obtained by other existing OVAL methods.</oval:reason>
+								<oval:comment>This attribute has been deprecated and will be removed in version 6.0.1 of the language.</oval:comment>
+							</oval:deprecated_info>
+						</xsd:appinfo>
+				  </xsd:annotation>
                   <xsd:simpleType>
                         <xsd:restriction base="xsd:string">
                               <xsd:enumeration value="32_bit"/>
@@ -4725,7 +4781,14 @@
                                     <xsd:element name="windows_view" type="win-def:EntityStateWindowsViewType" minOccurs="0">
                                           <xsd:annotation>
                                                 <xsd:documentation>The windows view value to which this was targeted. This is used to indicate which view (32-bit or 64-bit), the associated State applies to.</xsd:documentation>
-                                          </xsd:annotation>
+												<xsd:appinfo>
+													<oval:deprecated_info>
+														<oval:version>5.12.3</oval:version>
+														<oval:reason>Unused in production content and adds unneeded complexity to OVAL interpeters.  The equivalent data can be obtained by other existing OVAL methods.</oval:reason>
+														<oval:comment>This element has been deprecated and will be removed in version 6.0.1 of the language.</oval:comment>
+													</oval:deprecated_info>
+												</xsd:appinfo>
+										  </xsd:annotation>
                                     </xsd:element>
                               </xsd:sequence>
                         </xsd:extension>
@@ -5531,7 +5594,14 @@
                                     <xsd:element name="windows_view" type="win-def:EntityStateWindowsViewType" minOccurs="0">
                                           <xsd:annotation>
                                                 <xsd:documentation>The windows view value to which this was targeted. This is used to indicate which view (32-bit or 64-bit), the associated State applies to.</xsd:documentation>
-                                          </xsd:annotation>
+												<xsd:appinfo>
+													<oval:deprecated_info>
+														<oval:version>5.12.3</oval:version>
+														<oval:reason>Unused in production content and adds unneeded complexity to OVAL interpeters.  The equivalent data can be obtained by other existing OVAL methods.</oval:reason>
+														<oval:comment>This element has been deprecated and will be removed in version 6.0.1 of the language.</oval:comment>
+													</oval:deprecated_info>
+												</xsd:appinfo>
+										  </xsd:annotation>
                                     </xsd:element>
                               </xsd:sequence>
                         </xsd:extension>
@@ -5582,7 +5652,14 @@
                   <xsd:annotation>
                         <xsd:documentation>64-bit versions of Windows provide an alternate file system and registry views to 32-bit applications. This behavior allows the OVAL Object to specify which view should be examined. This behavior only applies to 64-bit Windows, and must not be applied on other platforms. </xsd:documentation>
                         <xsd:documentation>Note that the values have the following meaning: '64_bit' - Indicates that the 64-bit view on 64-bit Windows operating systems must be examined. On a 32-bit system, the Object must be evaluated without applying the behavior. '32_bit' - Indicates that the 32-bit view must be examined. On a 32-bit system, the Object must be evaluated without applying the behavior. It is recommended that the corresponding 'windows_view' entity be set on the OVAL Items that are collected when this behavior is used to distinguish between the OVAL Items that are collected in the 32-bit or 64-bit views.</xsd:documentation>
-                  </xsd:annotation>
+						<xsd:appinfo>
+							<oval:deprecated_info>
+								<oval:version>5.12.3</oval:version>
+								<oval:reason>Unused in production content and adds unneeded complexity to OVAL interpeters.  The equivalent data can be obtained by other existing OVAL methods.</oval:reason>
+								<oval:comment>This attribute has been deprecated and will be removed in version 6.0.1 of the language.</oval:comment>
+							</oval:deprecated_info>
+						</xsd:appinfo>
+				  </xsd:annotation>
                   <xsd:simpleType>
                         <xsd:restriction base="xsd:string">
                               <xsd:enumeration value="32_bit"/>
@@ -5827,7 +5904,14 @@
                                     <xsd:element name="windows_view" type="win-def:EntityStateWindowsViewType" minOccurs="0">
                                           <xsd:annotation>
                                                 <xsd:documentation>The windows view value to which this was targeted. This is used to indicate which view (32-bit or 64-bit), the associated State applies to.</xsd:documentation>
-                                          </xsd:annotation>
+												<xsd:appinfo>
+													<oval:deprecated_info>
+														<oval:version>5.12.3</oval:version>
+														<oval:reason>Unused in production content and adds unneeded complexity to OVAL interpeters.  The equivalent data can be obtained by other existing OVAL methods.</oval:reason>
+														<oval:comment>This element has been deprecated and will be removed in version 6.0.1 of the language.</oval:comment>
+													</oval:deprecated_info>
+												</xsd:appinfo>
+										  </xsd:annotation>
                                     </xsd:element>
                               </xsd:sequence>
                         </xsd:extension>
@@ -6114,7 +6198,14 @@
                                     <xsd:element name="windows_view" type="win-def:EntityStateWindowsViewType" minOccurs="0">
                                           <xsd:annotation>
                                                 <xsd:documentation>The windows view value to which this was targeted. This is used to indicate which view (32-bit or 64-bit), the associated State applies to.</xsd:documentation>
-                                          </xsd:annotation>
+												<xsd:appinfo>
+													<oval:deprecated_info>
+														<oval:version>5.12.3</oval:version>
+														<oval:reason>Unused in production content and adds unneeded complexity to OVAL interpeters.  The equivalent data can be obtained by other existing OVAL methods.</oval:reason>
+														<oval:comment>This element has been deprecated and will be removed in version 6.0.1 of the language.</oval:comment>
+													</oval:deprecated_info>
+												</xsd:appinfo>
+										  </xsd:annotation>
                                     </xsd:element>
                               </xsd:sequence>
                         </xsd:extension>
@@ -6402,7 +6493,14 @@
                                     <xsd:element name="windows_view" type="win-def:EntityStateWindowsViewType" minOccurs="0">
                                           <xsd:annotation>
                                                 <xsd:documentation>The windows view value to which this was targeted. This is used to indicate which view (32-bit or 64-bit), the associated State applies to.</xsd:documentation>
-                                          </xsd:annotation>
+												<xsd:appinfo>
+													<oval:deprecated_info>
+														<oval:version>5.12.3</oval:version>
+														<oval:reason>Unused in production content and adds unneeded complexity to OVAL interpeters.  The equivalent data can be obtained by other existing OVAL methods.</oval:reason>
+														<oval:comment>This element has been deprecated and will be removed in version 6.0.1 of the language.</oval:comment>
+													</oval:deprecated_info>
+												</xsd:appinfo>
+										  </xsd:annotation>
                                     </xsd:element>
                               </xsd:sequence>
                         </xsd:extension>
@@ -6687,7 +6785,14 @@
                                     <xsd:element name="windows_view" type="win-def:EntityStateWindowsViewType" minOccurs="0">
                                           <xsd:annotation>
                                                 <xsd:documentation>The windows view value to which this was targeted. This is used to indicate which view (32-bit or 64-bit), the associated State applies to.</xsd:documentation>
-                                          </xsd:annotation>
+												<xsd:appinfo>
+													<oval:deprecated_info>
+														<oval:version>5.12.3</oval:version>
+														<oval:reason>Unused in production content and adds unneeded complexity to OVAL interpeters.  The equivalent data can be obtained by other existing OVAL methods.</oval:reason>
+														<oval:comment>This element has been deprecated and will be removed in version 6.0.1 of the language.</oval:comment>
+													</oval:deprecated_info>
+												</xsd:appinfo>
+										  </xsd:annotation>
                                     </xsd:element>
                               </xsd:sequence>
                         </xsd:extension>

--- a/oval-schemas/windows-system-characteristics-schema.xsd
+++ b/oval-schemas/windows-system-characteristics-schema.xsd
@@ -1027,7 +1027,14 @@
                               <xsd:element name="windows_view" type="win-sc:EntityItemWindowsViewType" minOccurs="0">
                                    <xsd:annotation>
                                         <xsd:documentation>The windows view value from which this OVAL Item was collected. This is used to indicate from which view (32-bit or 64-bit), the associated Item was collected. A value of '32_bit' indicates the Item was collected from the 32-bit view.  A value of '64-bit' indicates the Item was collected from the 64-bit view. Omitting this entity removes any assertion about which view the Item was collected from, and therefore it is strongly suggested that this entity be set.</xsd:documentation>
-                                   </xsd:annotation>
+										<xsd:appinfo>
+											<oval:deprecated_info>
+												<oval:version>5.12.3</oval:version>
+												<oval:reason>Unused in production content and adds unneeded complexity to OVAL interpeters.  The equivalent data can be obtained by other existing OVAL methods.</oval:reason>
+												<oval:comment>This element has been deprecated and will be removed in version 6.0.1 of the language.</oval:comment>
+											</oval:deprecated_info>
+										</xsd:appinfo>
+									</xsd:annotation>
                               </xsd:element>
                          </xsd:sequence>
                     </xsd:extension>
@@ -1168,7 +1175,14 @@
                               <xsd:element name="windows_view" type="win-sc:EntityItemWindowsViewType" minOccurs="0">
                                    <xsd:annotation>
                                         <xsd:documentation>The windows view value from which this OVAL Item was collected. This is used to indicate from which view (32-bit or 64-bit), the associated Item was collected. A value of '32_bit' indicates the Item was collected from the 32-bit view.  A value of '64-bit' indicates the Item was collected from the 64-bit view. Omitting this entity removes any assertion about which view the Item was collected from, and therefore it is strongly suggested that this entity be set.</xsd:documentation>
-                                   </xsd:annotation>
+                                   			<xsd:appinfo>
+												<oval:deprecated_info>
+													<oval:version>5.12.3</oval:version>
+													<oval:reason>Unused in production content and adds unneeded complexity to OVAL interpeters.  The equivalent data can be obtained by other existing OVAL methods.</oval:reason>
+													<oval:comment>This element has been deprecated and will be removed in version 6.0.1 of the language.</oval:comment>
+												</oval:deprecated_info>
+											</xsd:appinfo>
+								   </xsd:annotation>
                               </xsd:element>
                          </xsd:sequence>
                     </xsd:extension>
@@ -1309,7 +1323,14 @@
                               <xsd:element name="windows_view" type="win-sc:EntityItemWindowsViewType" minOccurs="0">
                                    <xsd:annotation>
                                         <xsd:documentation>The windows view value from which this OVAL Item was collected. This is used to indicate from which view (32-bit or 64-bit), the associated Item was collected. A value of '32_bit' indicates the Item was collected from the 32-bit view.  A value of '64-bit' indicates the Item was collected from the 64-bit view. Omitting this entity removes any assertion about which view the Item was collected from, and therefore it is strongly suggested that this entity be set.</xsd:documentation>
-                                   </xsd:annotation>
+										<xsd:appinfo>
+											<oval:deprecated_info>
+												<oval:version>5.12.3</oval:version>
+												<oval:reason>Unused in production content and adds unneeded complexity to OVAL interpeters.  The equivalent data can be obtained by other existing OVAL methods.</oval:reason>
+												<oval:comment>This element has been deprecated and will be removed in version 6.0.1 of the language.</oval:comment>
+											</oval:deprecated_info>
+										</xsd:appinfo>
+								   </xsd:annotation>
                               </xsd:element>
                          </xsd:sequence>
                     </xsd:extension>
@@ -1489,7 +1510,14 @@
                               <xsd:element name="windows_view" type="win-sc:EntityItemWindowsViewType" minOccurs="0">
                                    <xsd:annotation>
                                         <xsd:documentation>The windows view value from which this OVAL Item was collected. This is used to indicate from which view (32-bit or 64-bit), the associated Item was collected. A value of '32_bit' indicates the Item was collected from the 32-bit view.  A value of '64-bit' indicates the Item was collected from the 64-bit view. Omitting this entity removes any assertion about which view the Item was collected from, and therefore it is strongly suggested that this entity be set.</xsd:documentation>
-                                   </xsd:annotation>
+										<xsd:appinfo>
+											<oval:deprecated_info>
+												<oval:version>5.12.3</oval:version>
+												<oval:reason>Unused in production content and adds unneeded complexity to OVAL interpeters.  The equivalent data can be obtained by other existing OVAL methods.</oval:reason>
+												<oval:comment>This element has been deprecated and will be removed in version 6.0.1 of the language.</oval:comment>
+											</oval:deprecated_info>
+										</xsd:appinfo>
+								   </xsd:annotation>
                               </xsd:element>
                          </xsd:sequence>
                     </xsd:extension>
@@ -2079,7 +2107,14 @@
                               <xsd:element name="loader_flags" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
                                    <xsd:annotation>
                                         <xsd:documentation>The loader_flags entity is an unsigned 32-bit integer (DWORD) that specifies the loader flags of the header.</xsd:documentation>
-                                   </xsd:annotation>
+										<xsd:appinfo>
+											<oval:deprecated_info>
+												<oval:version>5.12.3</oval:version>
+												<oval:reason>Unused in production content and adds unneeded complexity to OVAL interpeters.  The equivalent data can be obtained by other existing OVAL methods.</oval:reason>
+												<oval:comment>This element has been deprecated and will be removed in version 6.0.1 of the language.</oval:comment>
+											</oval:deprecated_info>
+										</xsd:appinfo>
+								   </xsd:annotation>
                               </xsd:element>
                               <xsd:element name="number_of_rva_and_sizes" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
                                    <xsd:annotation>
@@ -2094,7 +2129,14 @@
                               <xsd:element name="windows_view" type="win-sc:EntityItemWindowsViewType" minOccurs="0">
                                    <xsd:annotation>
                                         <xsd:documentation>The windows view value from which this OVAL Item was collected. This is used to indicate from which view (32-bit or 64-bit), the associated Item was collected. A value of '32_bit' indicates the Item was collected from the 32-bit view.  A value of '64-bit' indicates the Item was collected from the 64-bit view. Omitting this entity removes any assertion about which view the Item was collected from, and therefore it is strongly suggested that this entity be set.</xsd:documentation>
-                                   </xsd:annotation>
+										<xsd:appinfo>
+											<oval:deprecated_info>
+												<oval:version>5.12.3</oval:version>
+												<oval:reason>Unused in production content and adds unneeded complexity to OVAL interpeters.  The equivalent data can be obtained by other existing OVAL methods.</oval:reason>
+												<oval:comment>This element has been deprecated and will be removed in version 6.0.1 of the language.</oval:comment>
+											</oval:deprecated_info>
+										</xsd:appinfo>
+								   </xsd:annotation>
                               </xsd:element>
                          </xsd:sequence>
                     </xsd:extension>
@@ -2372,7 +2414,14 @@
                               <xsd:element name="windows_view" type="win-sc:EntityItemWindowsViewType" minOccurs="0">
                                    <xsd:annotation>
                                         <xsd:documentation>The windows view value from which this OVAL Item was collected. This is used to indicate from which view (32-bit or 64-bit), the associated Item was collected. A value of '32_bit' indicates the Item was collected from the 32-bit view.  A value of '64-bit' indicates the Item was collected from the 64-bit view. Omitting this entity removes any assertion about which view the Item was collected from, and therefore it is strongly suggested that this entity be set.</xsd:documentation>
-                                   </xsd:annotation>
+										<xsd:appinfo>
+											<oval:deprecated_info>
+												<oval:version>5.12.3</oval:version>
+												<oval:reason>Unused in production content and adds unneeded complexity to OVAL interpeters.  The equivalent data can be obtained by other existing OVAL methods.</oval:reason>
+												<oval:comment>This element has been deprecated and will be removed in version 6.0.1 of the language.</oval:comment>
+											</oval:deprecated_info>
+										</xsd:appinfo>
+								   </xsd:annotation>
                               </xsd:element>
                          </xsd:sequence>
                     </xsd:extension>
@@ -2519,7 +2568,14 @@
                               <xsd:element name="windows_view" type="win-sc:EntityItemWindowsViewType" minOccurs="0">
                                    <xsd:annotation>
                                         <xsd:documentation>The windows view value from which this OVAL Item was collected. This is used to indicate from which view (32-bit or 64-bit), the associated Item was collected. A value of '32_bit' indicates the Item was collected from the 32-bit view.  A value of '64-bit' indicates the Item was collected from the 64-bit view. Omitting this entity removes any assertion about which view the Item was collected from, and therefore it is strongly suggested that this entity be set.</xsd:documentation>
-                                   </xsd:annotation>
+										<xsd:appinfo>
+											<oval:deprecated_info>
+												<oval:version>5.12.3</oval:version>
+												<oval:reason>Unused in production content and adds unneeded complexity to OVAL interpeters.  The equivalent data can be obtained by other existing OVAL methods.</oval:reason>
+												<oval:comment>This element has been deprecated and will be removed in version 6.0.1 of the language.</oval:comment>
+											</oval:deprecated_info>
+										</xsd:appinfo>
+								   </xsd:annotation>
                               </xsd:element>
                          </xsd:sequence>
                     </xsd:extension>
@@ -2666,7 +2722,14 @@
                               <xsd:element name="windows_view" type="win-sc:EntityItemWindowsViewType" minOccurs="0">
                                    <xsd:annotation>
                                         <xsd:documentation>The windows view value from which this OVAL Item was collected. This is used to indicate from which view (32-bit or 64-bit), the associated Item was collected. A value of '32_bit' indicates the Item was collected from the 32-bit view.  A value of '64-bit' indicates the Item was collected from the 64-bit view. Omitting this entity removes any assertion about which view the Item was collected from, and therefore it is strongly suggested that this entity be set.</xsd:documentation>
-                                   </xsd:annotation>
+										<xsd:appinfo>
+											<oval:deprecated_info>
+												<oval:version>5.12.3</oval:version>
+												<oval:reason>Unused in production content and adds unneeded complexity to OVAL interpeters.  The equivalent data can be obtained by other existing OVAL methods.</oval:reason>
+												<oval:comment>This element has been deprecated and will be removed in version 6.0.1 of the language.</oval:comment>
+											</oval:deprecated_info>
+										</xsd:appinfo>
+								   </xsd:annotation>
                               </xsd:element>
                          </xsd:sequence>
                     </xsd:extension>


### PR DESCRIPTION
Documented the unused 'windows_view' as deprecated in 5.12.3 and to be removed in 6.0.1