### PR TITLE
Proposal: Add version_item Element to PAN-OS OVAL Schema #283

### DIFF
--- a/oval-schemas/panos-definitions-schema.xsd
+++ b/oval-schemas/panos-definitions-schema.xsd
@@ -2,7 +2,6 @@
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
             xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5"
             xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5"
-            xmlns:panos-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#panos"
             xmlns:sch="http://purl.oclc.org/dsdl/schematron"
             targetNamespace="http://oval.mitre.org/XMLSchema/oval-definitions-5#panos"
             elementFormDefault="qualified" version="5.12.3">

--- a/oval-schemas/panos-definitions-schema.xsd
+++ b/oval-schemas/panos-definitions-schema.xsd
@@ -5,7 +5,7 @@
             xmlns:panos-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#panos"
             xmlns:sch="http://purl.oclc.org/dsdl/schematron"
             targetNamespace="http://oval.mitre.org/XMLSchema/oval-definitions-5#panos"
-            elementFormDefault="qualified" version="5.12.2">
+            elementFormDefault="qualified" version="5.12.3">
     <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-definitions-5" schemaLocation="oval-definitions-schema.xsd"/>
     <xsd:annotation>
         <xsd:documentation>
@@ -24,8 +24,8 @@
         </xsd:documentation>
         <xsd:appinfo>
             <schema>Palo Alto (PAN-OS) Definitions</schema>
-            <version>5.12.2</version>
-            <date>11/25/2025 09:00:00 AM</date>
+            <version>5.12.3</version>
+            <date>05/29/2026 09:00:00 AM</date>
             <terms_of_use>
                 For the portion subject to the copyright in the United States: Copyright (c) 2016 United States Government. 
                 All rights reserved. Copyright (c) 2016, Center for Internet Security. All rights reserved. The contents of 
@@ -167,5 +167,98 @@
                 </xsd:extension>
             </xsd:complexContent>
         </xsd:complexType>
+    </xsd:element>
+
+    <!-- ============================================================================ -->
+    <!-- ================================ VERSION TEST  ============================= -->
+    <!-- ============================================================================ -->
+    <xsd:element name="version_test" substitutionGroup="oval-def:test">
+        <xsd:annotation>
+              <xsd:documentation>The version_test is used to check the version from a PAN-OS XML API request. 
+              This is a request to the API at "https://[PAN-OS-DEVICE]/api/?type=op&amp;cmd=&lt;show&gt;&lt;system&gt;&lt;info&gt;&lt;/info&gt;&lt;/system&gt;&lt;/show&gt;".
+              The response to this request is an XML payload rooted with a "response" element and including device-specific information.
+              It extends the standard TestType as defined in the oval-definitions-schema and one should refer to the TestType description for more information. The required object element references a version_object and the optional state element specifies the data to check.</xsd:documentation>
+              <xsd:appinfo>
+                    <oval:element_mapping>
+                          <oval:test>version_test</oval:test>
+                          <oval:object>version_object</oval:object>
+                          <oval:state>version_state</oval:state>
+                          <oval:item target_namespace="urn:oval:v6:system-characteristics:panos">version_item</oval:item>
+                    </oval:element_mapping>
+              </xsd:appinfo>
+              <xsd:appinfo>
+                    <sch:pattern id="panos-def_versiontst">
+                          <sch:rule context="panos-def:version_test/panos-def:object">
+                                <sch:assert test="@object_ref=ancestor::oval-def:oval_definitions/oval-def:objects/panos-def:version_object/@id"><sch:value-of select="../@id"/> - the object child element of a version_test must reference a version_object</sch:assert>
+                          </sch:rule>
+                          <sch:rule context="panos-def:version_test/panos-def:state">
+                                <sch:assert test="@state_ref=ancestor::oval-def:oval_definitions/oval-def:states/panos-def:version_state/@id"><sch:value-of select="../@id"/> - the state child element of a version_test must reference a version_state</sch:assert>
+                          </sch:rule>
+                    </sch:pattern>
+              </xsd:appinfo>
+        </xsd:annotation>
+        <xsd:complexType>
+              <xsd:complexContent>
+                    <xsd:extension base="oval-def:TestType">
+                          <xsd:sequence>
+                                <xsd:element name="object" type="oval-def:ObjectRefType" />
+                                <xsd:element name="state" type="oval-def:StateRefType" minOccurs="0" maxOccurs="unbounded"/>
+                          </xsd:sequence>
+                    </xsd:extension>
+              </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+    <xsd:element name="version_object" substitutionGroup="oval-def:object">
+          <xsd:annotation>
+                <xsd:documentation>The version_object element is used by a version_test to define the different version information associated with an PANOS system. There is actually only one object relating to version and this is the system as a whole. Therefore, there are no child entities defined. Any OVAL Test written to check version will reference the same version_object which is basically an empty object element.</xsd:documentation>
+          </xsd:annotation>
+          <xsd:complexType>
+                <xsd:complexContent>
+                      <xsd:extension base="oval-def:ObjectType"/>
+                </xsd:complexContent>
+          </xsd:complexType>
+    </xsd:element>
+    <xsd:element name="version_state" substitutionGroup="oval-def:state">
+          <xsd:annotation>
+                <xsd:documentation>The version_state element defines the version information held within a PANOS Release.</xsd:documentation>
+          </xsd:annotation>
+          <xsd:complexType>
+                <xsd:complexContent>
+                      <xsd:extension base="oval-def:StateType">
+                            <xsd:sequence>
+                                <xsd:element name="major_version" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+                                    <xsd:annotation>
+                                        <xsd:documentation>The major_version entity is used to check the major version piece of the version string. The value is an integer and in the example 10.1.14-h9 the major version is '10'.</xsd:documentation>
+                                    </xsd:annotation>
+                                </xsd:element>
+                                <xsd:element name="minor_version" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+                                    <xsd:annotation>
+                                        <xsd:documentation>The minor_version entity is used to check the minor version piece of the version string. The value is an integer and in the example 10.1.14-h9 the minor version is '1'.</xsd:documentation>
+                                    </xsd:annotation>
+                                </xsd:element>
+                                <xsd:element name="release" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+                                    <xsd:annotation>
+                                        <xsd:documentation>The release entity is used to check the release piece of the version string. The value is an integer and in the example 10.1.14-h9 the release is '14'.</xsd:documentation>
+                                    </xsd:annotation>
+                                </xsd:element>
+                                <xsd:element name="hotfix" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+                                    <xsd:annotation>
+                                        <xsd:documentation>The Hotfix entity is used to check the hotfix piece of the version string. The value is an integer and in the example 10.1.14-h9 the hotfix is '9'.</xsd:documentation>
+                                    </xsd:annotation>
+                                </xsd:element>
+                                <xsd:element name="version_string" type="oval-def:EntityStateAnySimpleType" minOccurs="0" maxOccurs="1">
+                                    <xsd:annotation>
+                                        <xsd:documentation>The version_string entity is used to check the sw-version raw string output of a PAN-OS XML API request. The value is an string and the example 10.1.14-h9</xsd:documentation>
+                                    </xsd:annotation>
+                                </xsd:element>
+                                <xsd:element name="model_name" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                                    <xsd:annotation>
+                                        <xsd:documentation>The model_name entity is used to check the model string output of a PAN-OS XML API request.</xsd:documentation>
+                                    </xsd:annotation>
+                                </xsd:element>
+                            </xsd:sequence>
+                      </xsd:extension>
+                </xsd:complexContent>
+          </xsd:complexType>
     </xsd:element>
 </xsd:schema>

--- a/oval-schemas/panos-system-characteristics-schema.xsd
+++ b/oval-schemas/panos-system-characteristics-schema.xsd
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
             xmlns:oval-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5"
-            xmlns:panos-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#panos"
             xmlns:sch="http://purl.oclc.org/dsdl/schematron"
             targetNamespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#panos"
             elementFormDefault="qualified" version="5.12.3">

--- a/oval-schemas/panos-system-characteristics-schema.xsd
+++ b/oval-schemas/panos-system-characteristics-schema.xsd
@@ -69,38 +69,38 @@
     <!-- =============================================================================== -->
     <xsd:element name="version_item" substitutionGroup="oval-sc:item">
         <xsd:annotation>
-            <xsd:documentation>This item stores results from checking the contents of an XML configuration.</xsd:documentation>
+            <xsd:documentation>The version_item holds information about the version of a PAN-OS system. It is retrieved from the PAN-OS XML API "show system info" response, which contains the sw-version and model fields.</xsd:documentation>
         </xsd:annotation>
         <xsd:complexType>
             <xsd:complexContent>
-                <xsd:extension base="oval-def:StateType">
+                <xsd:extension base="oval-def:ItemType">
                     <xsd:sequence>
-                        <xsd:element name="major_version" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+                        <xsd:element name="major_version" type="oval-def:EntityItemIntType" minOccurs="0" maxOccurs="1">
                             <xsd:annotation>
                                 <xsd:documentation>The major_version entity is used to check the major version piece of the version string. The value is an integer and in the example 10.1.14-h9 the major version is '10'.</xsd:documentation>
                             </xsd:annotation>
                         </xsd:element>
-                        <xsd:element name="minor_version" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+                        <xsd:element name="minor_version" type="oval-def:EntityItemIntType" minOccurs="0" maxOccurs="1">
                             <xsd:annotation>
                                 <xsd:documentation>The minor_version entity is used to check the minor version piece of the version string. The value is an integer and in the example 10.1.14-h9 the minor version is '1'.</xsd:documentation>
                             </xsd:annotation>
                         </xsd:element>
-                        <xsd:element name="release" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+                        <xsd:element name="release" type="oval-def:EntityItemIntType" minOccurs="0" maxOccurs="1">
                             <xsd:annotation>
                                 <xsd:documentation>The release entity is used to check the release piece of the version string. The value is an integer and in the example 10.1.14-h9 the release is '14'.</xsd:documentation>
                             </xsd:annotation>
                         </xsd:element>
-                        <xsd:element name="hotfix" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+                        <xsd:element name="hotfix" type="oval-def:EntityItemIntType" minOccurs="0" maxOccurs="1">
                             <xsd:annotation>
                                 <xsd:documentation>The hotfix entity is used to check the hotfix piece of the version string. The value is an integer and in the example 10.1.14-h9 the hotfix is '9'.</xsd:documentation>
                             </xsd:annotation>
                         </xsd:element>
-                        <xsd:element name="version_string" type="oval-def:EntityStateAnySimpleType" minOccurs="0" maxOccurs="1">
+                        <xsd:element name="version_string" type="oval-def:EntityItemAnySimpleType" minOccurs="0" maxOccurs="1">
                             <xsd:annotation>
                                 <xsd:documentation>The version_string entity is used to check the sw-version raw string output of a PAN-OS XML API request. The value is an string and the example 10.1.14-h9. This is entirely controlled by operator attributes.</xsd:documentation>
                             </xsd:annotation>
                         </xsd:element>
-                        <xsd:element name="model_name" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                        <xsd:element name="model_name" type="oval-def:EntityItemStringType" minOccurs="0" maxOccurs="1">
                             <xsd:annotation>
                                 <xsd:documentation>The model_name entity is used to check the model string output of a PAN-OS XML API request.</xsd:documentation>
                             </xsd:annotation>

--- a/oval-schemas/panos-system-characteristics-schema.xsd
+++ b/oval-schemas/panos-system-characteristics-schema.xsd
@@ -73,34 +73,34 @@
         </xsd:annotation>
         <xsd:complexType>
             <xsd:complexContent>
-                <xsd:extension base="oval-def:ItemType">
+                <xsd:extension base="oval-sc:ItemType">
                     <xsd:sequence>
-                        <xsd:element name="major_version" type="oval-def:EntityItemIntType" minOccurs="0" maxOccurs="1">
+                        <xsd:element name="major_version" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
                             <xsd:annotation>
                                 <xsd:documentation>The major_version entity is used to check the major version piece of the version string. The value is an integer and in the example 10.1.14-h9 the major version is '10'.</xsd:documentation>
                             </xsd:annotation>
                         </xsd:element>
-                        <xsd:element name="minor_version" type="oval-def:EntityItemIntType" minOccurs="0" maxOccurs="1">
+                        <xsd:element name="minor_version" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
                             <xsd:annotation>
                                 <xsd:documentation>The minor_version entity is used to check the minor version piece of the version string. The value is an integer and in the example 10.1.14-h9 the minor version is '1'.</xsd:documentation>
                             </xsd:annotation>
                         </xsd:element>
-                        <xsd:element name="release" type="oval-def:EntityItemIntType" minOccurs="0" maxOccurs="1">
+                        <xsd:element name="release" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
                             <xsd:annotation>
                                 <xsd:documentation>The release entity is used to check the release piece of the version string. The value is an integer and in the example 10.1.14-h9 the release is '14'.</xsd:documentation>
                             </xsd:annotation>
                         </xsd:element>
-                        <xsd:element name="hotfix" type="oval-def:EntityItemIntType" minOccurs="0" maxOccurs="1">
+                        <xsd:element name="hotfix" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
                             <xsd:annotation>
                                 <xsd:documentation>The hotfix entity is used to check the hotfix piece of the version string. The value is an integer and in the example 10.1.14-h9 the hotfix is '9'.</xsd:documentation>
                             </xsd:annotation>
                         </xsd:element>
-                        <xsd:element name="version_string" type="oval-def:EntityItemAnySimpleType" minOccurs="0" maxOccurs="1">
+                        <xsd:element name="version_string" type="oval-sc:EntityItemAnySimpleType" minOccurs="0" maxOccurs="1">
                             <xsd:annotation>
                                 <xsd:documentation>The version_string entity is used to check the sw-version raw string output of a PAN-OS XML API request. The value is an string and the example 10.1.14-h9. This is entirely controlled by operator attributes.</xsd:documentation>
                             </xsd:annotation>
                         </xsd:element>
-                        <xsd:element name="model_name" type="oval-def:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                        <xsd:element name="model_name" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
                             <xsd:annotation>
                                 <xsd:documentation>The model_name entity is used to check the model string output of a PAN-OS XML API request.</xsd:documentation>
                             </xsd:annotation>

--- a/oval-schemas/panos-system-characteristics-schema.xsd
+++ b/oval-schemas/panos-system-characteristics-schema.xsd
@@ -4,7 +4,7 @@
             xmlns:panos-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#panos"
             xmlns:sch="http://purl.oclc.org/dsdl/schematron"
             targetNamespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#panos"
-            elementFormDefault="qualified" version="5.12.2">
+            elementFormDefault="qualified" version="5.12.3">
     <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5" schemaLocation="oval-system-characteristics-schema.xsd"/>
     <xsd:annotation>
         <xsd:documentation>
@@ -19,8 +19,8 @@
         </xsd:documentation>
         <xsd:appinfo>
             <schema>Palo Alto (PAN-OS) Definitions</schema>
-            <version>5.12.2</version>
-            <date>11/25/2025 09:00:00 AM</date>
+            <version>5.12.3</version>
+            <date>05/29/2026 09:00:00 AM</date>
             <terms_of_use>
                 For the portion subject to the copyright in the United States: Copyright (c) 2016 United States Government. 
                 All rights reserved. Copyright (c) 2016, Center for Internet Security. All rights reserved. The contents of 
@@ -56,6 +56,53 @@
                                     The value_of element checks the value(s) of the text node(s) or attribute(s) found. How this 
                                     is used is entirely controlled by operator attributes.
                                 </xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                    </xsd:sequence>
+                </xsd:extension>
+            </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+    
+    <!-- =============================================================================== -->
+    <!-- ===============================  VERSION ITEM  ================================ -->
+    <!-- =============================================================================== -->
+    <xsd:element name="version_item" substitutionGroup="oval-sc:item">
+        <xsd:annotation>
+            <xsd:documentation>This item stores results from checking the contents of an XML configuration.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:complexContent>
+                <xsd:extension base="oval-def:StateType">
+                    <xsd:sequence>
+                        <xsd:element name="major_version" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>The major_version entity is used to check the major version piece of the version string. The value is an integer and in the example 10.1.14-h9 the major version is '10'.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="minor_version" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>The minor_version entity is used to check the minor version piece of the version string. The value is an integer and in the example 10.1.14-h9 the minor version is '1'.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="release" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>The release entity is used to check the release piece of the version string. The value is an integer and in the example 10.1.14-h9 the release is '14'.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="hotfix" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>The hotfix entity is used to check the hotfix piece of the version string. The value is an integer and in the example 10.1.14-h9 the hotfix is '9'.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="version_string" type="oval-def:EntityStateAnySimpleType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>The version_string entity is used to check the sw-version raw string output of a PAN-OS XML API request. The value is an string and the example 10.1.14-h9. This is entirely controlled by operator attributes.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="model_name" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>The model_name entity is used to check the model string output of a PAN-OS XML API request.</xsd:documentation>
                             </xsd:annotation>
                         </xsd:element>
                     </xsd:sequence>


### PR DESCRIPTION
## Abstarct

This PR enhances the PAN-OS OVAL schema by introducing a new element `version_item` in both definitions and system-characteristics schemas. As per the current PAN-OS XSD Statement (OVAL 5.12 and 6.0), the `<config_item>` element only collects information from:

```
https://<PAN-OS-DEVICE>/api/?type=export&category=configuration
```

This API is not sufficient to capture full system information.

### Real-Time System Analysis Summary:

| Element Name    | Description                                                                 |
|----------------|-----------------------------------------------------------------------------|
| `config_item`   | Only collects the running configuration from the PAN-OS device. Information like `DeviceName`, `DeviceVersion`, etc., is **missing** in the response. |
| `version_item`  | Collects **device-specific information** such as `Model Name`, `Device Version`, `License Status`, etc. |

➡️ `version_item` is proposed as a **new schema element** to bridge this gap.

---

### Real-Time Device Analysis (PA-VM - PAN-OS v11.0.5)

Example CLI Output:
```bash
admin@PA-VM> show system info

hostname: PA-VM
ip-address: 192.168.122.26
family: vm
model: PA-VM
serial: unknown
vm-license: none
sw-version: 11.0.5
```

Example API Request Flow:
```bash
# Get API Key
curl -s -k 'https://192.168.122.26/api/?type=keygen&user=admin&password=admin'

# Example Response
<response status='success'>
  <result>
    <key>LUFRPT1X...</key>
  </result>
</response>

# Use API Key to get config
APIKEY="LUFRPT1X..."
curl -s -k "https://192.168.122.26/api/?key=$APIKEY&type=export&category=configuration"
```

Example Configuration Output:
```xml
<config version="11.0.0" urldb="paloaltonetworks" detail-version="11.0.0">
  <mgt-config>...</mgt-config>
</config>
```

➡️ As seen above, **`sw-version` and other critical system information are not represented in the configuration XML** — hence the need for `version_item`.

---

## Changes Introduced
- `version_item` in `panos-definitions-schema.xsd`
- `version_item` in `panos-system-characteristics-schema.xsd`